### PR TITLE
fix(sqlite): [UPD] default SQLite path to core/database

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (o
 - `--db-type`: Database type (`mysql`, `pgsql`, `sqlite`, or `sqlsrv`)
 - `--db-host`: Database host (default: `localhost`, not used for SQLite)
 - `--db-port`: Database port (defaults: 3306 for MySQL, 5432 for PostgreSQL, 1433 for SQL Server)
-- `--db-name`: Database name (for SQLite: path to database file, default: `core/database/database.sqlite`)
+- `--db-name`: Database name (for SQLite: database file name stored under `core/database/`, default: `database.sqlite`)
 - `--db-user`: Database user (not used for SQLite)
 - `--db-password`: Database password (not used for SQLite). If it contains shell special characters (e.g. `;`, `&`, `!`), quote it: `--db-password='p;ass'`.
 - `--admin-username`: Admin username
@@ -148,7 +148,7 @@ evo install demo \
   --cli \
   --branch=3.5.x \
   --db-type=sqlite \
-  --db-name=core/database/database.sqlite \
+  --db-name=database.sqlite \
   --admin-username=admin \
   --admin-email=admin@example.com \
   --admin-password=123456 \

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (o
 - `--db-type`: Database type (`mysql`, `pgsql`, `sqlite`, or `sqlsrv`)
 - `--db-host`: Database host (default: `localhost`, not used for SQLite)
 - `--db-port`: Database port (defaults: 3306 for MySQL, 5432 for PostgreSQL, 1433 for SQL Server)
-- `--db-name`: Database name (for SQLite: path to database file, default: `database.sqlite`)
+- `--db-name`: Database name (for SQLite: path to database file, default: `core/database/database.sqlite`)
 - `--db-user`: Database user (not used for SQLite)
 - `--db-password`: Database password (not used for SQLite). If it contains shell special characters (e.g. `;`, `&`, `!`), quote it: `--db-password='p;ass'`.
 - `--admin-username`: Admin username
@@ -148,7 +148,7 @@ evo install demo \
   --cli \
   --branch=3.5.x \
   --db-type=sqlite \
-  --db-name=database.sqlite \
+  --db-name=core/database/database.sqlite \
   --admin-username=admin \
   --admin-email=admin@example.com \
   --admin-password=123456 \

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -509,8 +509,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 						Active:  true,
 						ID:      "db_sqlite_path",
 						Kind:    domain.QuestionInput,
-						Prompt:  "What is the path to your SQLite database file?",
-						Default: defaultSQLiteDatabasePath(),
+						Prompt:  "What is the name of your SQLite database file?",
+						Default: defaultSQLiteDatabaseName(),
 					})
 					if !ok {
 						return
@@ -524,7 +524,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 					Source:   "install",
 					Severity: domain.SeverityInfo,
 					Payload: domain.LogPayload{
-						Message: "Selected database path: " + dbName + ".",
+						Message: "Selected database name: " + dbName + ".",
 					},
 				})
 			default:
@@ -1763,8 +1763,8 @@ func defaultPort(dbType string) int {
 	}
 }
 
-func defaultSQLiteDatabasePath() string {
-	return filepath.ToSlash(filepath.Join("core", "database", "database.sqlite"))
+func defaultSQLiteDatabaseName() string {
+	return "database.sqlite"
 }
 
 func dbDriverLabel(dbType string) string {
@@ -1854,7 +1854,10 @@ try {
   $pass = $cfg["password"] ?? "";
   $timeout = [\PDO::ATTR_TIMEOUT => 5];
   if ($type === "sqlite") {
-    if ($name === "") { echo json_encode(["ok"=>false,"error"=>"SQLite database path is required."]); exit(0); }
+    if ($name === "") { echo json_encode(["ok"=>false,"error"=>"SQLite database name is required."]); exit(0); }
+    if ($name !== ":memory:" && !str_starts_with($name, "file:") && !preg_match('/^(\/|[A-Za-z]:[\\\\\\/])/', $name)) {
+      $name = "core/database/" . basename(str_replace("\\", "/", $name));
+    }
     new \PDO("sqlite:".$name, null, null, $timeout);
     echo json_encode(["ok"=>true]); exit(0);
   }

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -510,7 +510,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 						ID:      "db_sqlite_path",
 						Kind:    domain.QuestionInput,
 						Prompt:  "What is the path to your SQLite database file?",
-						Default: "database.sqlite",
+						Default: defaultSQLiteDatabasePath(),
 					})
 					if !ok {
 						return
@@ -1761,6 +1761,10 @@ func defaultPort(dbType string) int {
 	default:
 		return 3306
 	}
+}
+
+func defaultSQLiteDatabasePath() string {
+	return filepath.ToSlash(filepath.Join("core", "database", "database.sqlite"))
 }
 
 func dbDriverLabel(dbType string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -523,7 +523,7 @@ var logValuePrefixes = []string{
 	"Selected database name:",
 	"Selected database user:",
 	"Selected database password:",
-	"Selected database path:",
+	"Selected database name:",
 	"Your Admin username:",
 	"Your Admin email:",
 	"Your Admin password:",

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -396,14 +396,15 @@ class InstallCommand extends Command
     protected function askDatabaseName(?string $type = null): string
     {
         if ($type === 'sqlite') {
+            $defaultPath = $this->defaultSqliteDatabasePath();
             $answer = $this->tui->ask(
                 'What is the path to your SQLite database file?',
-                'database.sqlite'
+                $defaultPath
             );
 
             $this->tui->replaceLastLogs('<fg=green>✔</> Selected database path: ' . $answer . '.', 2);
 
-            return $answer ?: 'database.sqlite';
+            return $this->normalizeSqliteDatabasePath($answer ?: $defaultPath);
         }
 
         $answer = $this->tui->ask(
@@ -3323,7 +3324,8 @@ class InstallCommand extends Command
             return $dbConfig;
         }
 
-        $name = (string) ($dbConfig['name'] ?? '');
+        $name = $this->normalizeSqliteDatabasePath((string) ($dbConfig['name'] ?? ''));
+        $dbConfig['name'] = $name;
         if ($name === '' || $name === ':memory:' || str_starts_with($name, 'file:')) {
             return $dbConfig;
         }
@@ -3336,6 +3338,40 @@ class InstallCommand extends Command
 
         $dbConfig['name'] = rtrim($projectPath, '/\\') . DIRECTORY_SEPARATOR . $name;
         return $dbConfig;
+    }
+
+    protected function defaultSqliteDatabasePath(): string
+    {
+        return 'core/database/database.sqlite';
+    }
+
+    protected function normalizeSqliteDatabasePath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return $this->defaultSqliteDatabasePath();
+        }
+
+        if ($path === ':memory:' || str_starts_with($path, 'file:')) {
+            return $path;
+        }
+
+        if (str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1) {
+            return $path;
+        }
+
+        $normalized = str_replace('\\', '/', $path);
+        $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
+        $normalized = ltrim($normalized, '/');
+        if ($normalized === '') {
+            return $this->defaultSqliteDatabasePath();
+        }
+
+        if (!str_contains($normalized, '/')) {
+            return 'core/database/' . $normalized;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -391,20 +391,20 @@ class InstallCommand extends Command
     /**
      * Ask for database name.
      *
-     * @param string|null $type Database type (for SQLite, asks for file path)
+     * @param string|null $type Database type (for SQLite, asks for file name)
      */
     protected function askDatabaseName(?string $type = null): string
     {
         if ($type === 'sqlite') {
-            $defaultPath = $this->defaultSqliteDatabasePath();
+            $defaultName = $this->defaultSqliteDatabaseName();
             $answer = $this->tui->ask(
-                'What is the path to your SQLite database file?',
-                $defaultPath
+                'What is the name of your SQLite database file?',
+                $defaultName
             );
 
-            $this->tui->replaceLastLogs('<fg=green>✔</> Selected database path: ' . $answer . '.', 2);
+            $this->tui->replaceLastLogs('<fg=green>✔</> Selected database name: ' . $answer . '.', 2);
 
-            return $this->normalizeSqliteDatabasePath($answer ?: $defaultPath);
+            return $this->normalizeSqliteDatabaseName($answer ?: $defaultName);
         }
 
         $answer = $this->tui->ask(
@@ -491,8 +491,8 @@ class InstallCommand extends Command
             if ($type === 'sqlite') {
                 // SQLite: Connect directly to the database file
                 if (empty($config['name'])) {
-                    $this->tui->replaceLastLogs('<fg=red>✗</> Database connection failed: SQLite database path is required.', 2);
-                    $this->lastDatabaseConnectionError = 'SQLite database path is required.';
+                    $this->tui->replaceLastLogs('<fg=red>✗</> Database connection failed: SQLite database name is required.', 2);
+                    $this->lastDatabaseConnectionError = 'SQLite database name is required.';
                     return false;
                 }
                 $this->createConnection($config);
@@ -2682,7 +2682,7 @@ class InstallCommand extends Command
 
         if ($type === 'sqlite') {
             if ($dbName === '') {
-                throw new \RuntimeException('SQLite database path is empty.');
+                throw new \RuntimeException('SQLite database name is empty.');
             }
             if ($dbName !== ':memory:' && !str_starts_with($dbName, 'file:') && !is_file($dbName)) {
                 throw new \RuntimeException("SQLite database file not found: {$dbName}");
@@ -3324,7 +3324,7 @@ class InstallCommand extends Command
             return $dbConfig;
         }
 
-        $name = $this->normalizeSqliteDatabasePath((string) ($dbConfig['name'] ?? ''));
+        $name = $this->resolveSqliteDatabasePath((string) ($dbConfig['name'] ?? ''));
         $dbConfig['name'] = $name;
         if ($name === '' || $name === ':memory:' || str_starts_with($name, 'file:')) {
             return $dbConfig;
@@ -3340,16 +3340,16 @@ class InstallCommand extends Command
         return $dbConfig;
     }
 
-    protected function defaultSqliteDatabasePath(): string
+    protected function defaultSqliteDatabaseName(): string
     {
-        return 'core/database/database.sqlite';
+        return 'database.sqlite';
     }
 
-    protected function normalizeSqliteDatabasePath(string $path): string
+    protected function resolveSqliteDatabasePath(string $path): string
     {
         $path = trim($path);
         if ($path === '') {
-            return $this->defaultSqliteDatabasePath();
+            return 'core/database/' . $this->defaultSqliteDatabaseName();
         }
 
         if ($path === ':memory:' || str_starts_with($path, 'file:')) {
@@ -3360,18 +3360,22 @@ class InstallCommand extends Command
             return $path;
         }
 
-        $normalized = str_replace('\\', '/', $path);
+        return 'core/database/' . $this->normalizeSqliteDatabaseName($path);
+    }
+
+    protected function normalizeSqliteDatabaseName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            return $this->defaultSqliteDatabaseName();
+        }
+
+        $normalized = str_replace('\\', '/', $name);
         $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
-        $normalized = ltrim($normalized, '/');
-        if ($normalized === '') {
-            return $this->defaultSqliteDatabasePath();
-        }
+        $normalized = trim($normalized, '/');
+        $basename = basename($normalized);
 
-        if (!str_contains($normalized, '/')) {
-            return 'core/database/' . $normalized;
-        }
-
-        return $normalized;
+        return ($basename !== '' && $basename !== '.') ? $basename : $this->defaultSqliteDatabaseName();
     }
 
     /**

--- a/src/Concerns/ConfiguresDatabase.php
+++ b/src/Concerns/ConfiguresDatabase.php
@@ -270,16 +270,13 @@ trait ConfiguresDatabase
     {
         $normalized = trim(str_replace('\\', '/', $path));
         $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
-        $normalized = ltrim($normalized, '/');
-        if ($normalized === '') {
+        $normalized = trim($normalized, '/');
+        $basename = basename($normalized);
+        if ($basename === '' || $basename === '.') {
             return $this->defaultSqliteDatabasePath();
         }
 
-        if (!str_contains($normalized, '/')) {
-            return 'core/database/' . $normalized;
-        }
-
-        return $normalized;
+        return 'core/database/' . $basename;
     }
 
     protected function isAbsolutePath(string $path): bool

--- a/src/Concerns/ConfiguresDatabase.php
+++ b/src/Concerns/ConfiguresDatabase.php
@@ -82,7 +82,10 @@ trait ConfiguresDatabase
     {
         if ($type === 'sqlite') {
             // SQLite: database is the path to the file
-            $path = $database ?: ':memory:';
+            $path = $database ?: $this->defaultSqliteDatabasePath();
+            if ($path !== ':memory:' && !str_starts_with($path, 'file:') && !$this->isAbsolutePath($path)) {
+                $path = $this->normalizeRelativeSqliteDatabasePath($path);
+            }
             return "sqlite:{$path}";
         }
 
@@ -153,7 +156,10 @@ trait ConfiguresDatabase
 
         if ($type === 'sqlite') {
             // SQLite: Create database file
-            $databasePath = $databaseName ?: 'database.sqlite';
+            $databasePath = $databaseName ?: $this->defaultSqliteDatabasePath();
+            if ($databasePath !== ':memory:' && !str_starts_with($databasePath, 'file:') && !$this->isAbsolutePath($databasePath)) {
+                $databasePath = $this->normalizeRelativeSqliteDatabasePath($databasePath);
+            }
             $directory = dirname($databasePath);
             
             if (!empty($directory) && !is_dir($directory)) {
@@ -253,5 +259,33 @@ trait ConfiguresDatabase
             Console::error("Failed to create database: " . $e->getMessage());
             return false;
         }
+    }
+
+    protected function defaultSqliteDatabasePath(): string
+    {
+        return 'core/database/database.sqlite';
+    }
+
+    protected function normalizeRelativeSqliteDatabasePath(string $path): string
+    {
+        $normalized = trim(str_replace('\\', '/', $path));
+        $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
+        $normalized = ltrim($normalized, '/');
+        if ($normalized === '') {
+            return $this->defaultSqliteDatabasePath();
+        }
+
+        if (!str_contains($normalized, '/')) {
+            return 'core/database/' . $normalized;
+        }
+
+        return $normalized;
+    }
+
+    protected function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\\\')
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
     }
 }

--- a/src/Process/CreatesDatabaseConfig.php
+++ b/src/Process/CreatesDatabaseConfig.php
@@ -149,16 +149,13 @@ PHP;
 
         $normalized = str_replace('\\', '/', $path);
         $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
-        $normalized = ltrim($normalized, '/');
-        if ($normalized === '') {
+        $normalized = trim($normalized, '/');
+        $basename = basename($normalized);
+        if ($basename === '' || $basename === '.') {
             return 'core/database/database.sqlite';
         }
 
-        if (!str_contains($normalized, '/')) {
-            return 'core/database/' . $normalized;
-        }
-
-        return $normalized;
+        return 'core/database/' . $basename;
     }
 
     protected function isAbsolutePath(string $path): bool

--- a/src/Process/CreatesDatabaseConfig.php
+++ b/src/Process/CreatesDatabaseConfig.php
@@ -89,10 +89,13 @@ class CreatesDatabaseConfig
     protected function generateConfigContent(array $params): string
     {
         $rawDriver = (string) $params['driver'];
+        $rawDatabase = (string) $params['database'];
+        if ($rawDriver === 'sqlite') {
+            $rawDatabase = $this->normalizeSqliteDatabasePath($rawDatabase);
+        }
         $driver = $this->escapePhpString($rawDriver);
         $host = $this->escapePhpString((string) $params['host']);
         $port = $this->escapePhpString((string) ($params['port'] ?? ''));
-        $rawDatabase = (string) $params['database'];
         $database = $this->escapePhpString($rawDatabase);
         $username = $this->escapePhpString((string) $params['username']);
         $password = $this->escapePhpString((string) $params['password']);
@@ -131,6 +134,31 @@ class CreatesDatabaseConfig
     ]
 ];
 PHP;
+    }
+
+    protected function normalizeSqliteDatabasePath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return 'core/database/database.sqlite';
+        }
+
+        if ($path === ':memory:' || str_starts_with($path, 'file:') || $this->isAbsolutePath($path)) {
+            return $path;
+        }
+
+        $normalized = str_replace('\\', '/', $path);
+        $normalized = preg_replace('#^(?:\./)+#', '', $normalized) ?? $normalized;
+        $normalized = ltrim($normalized, '/');
+        if ($normalized === '') {
+            return 'core/database/database.sqlite';
+        }
+
+        if (!str_contains($normalized, '/')) {
+            return 'core/database/' . $normalized;
+        }
+
+        return $normalized;
     }
 
     protected function isAbsolutePath(string $path): bool

--- a/tests/Unit/CreatesDatabaseConfigTest.php
+++ b/tests/Unit/CreatesDatabaseConfigTest.php
@@ -73,6 +73,34 @@ class CreatesDatabaseConfigTest extends TestCase
         $this->assertStringContainsString("'engine' => env('DB_ENGINE', '')", $content);
     }
 
+    public function testGenerateConfigContentForSqliteUsesCoreDatabaseDefaultPath(): void
+    {
+        $reflection = new \ReflectionClass($this->processor);
+        $method = $reflection->getMethod('generateConfigContent');
+        $method->setAccessible(true);
+
+        $params = [
+            'driver' => 'sqlite',
+            'host' => '',
+            'port' => null,
+            'database' => 'database.sqlite',
+            'username' => '',
+            'password' => '',
+            'charset' => 'utf8',
+            'collation' => 'utf8',
+            'prefix' => 'evo_',
+            'method' => 'SET CHARACTER SET',
+            'engine' => '',
+        ];
+
+        $content = $method->invoke($this->processor, $params);
+
+        $this->assertStringContainsString(
+            "'database' => env('DB_DATABASE', dirname(__DIR__, 4) . '/core/database/database.sqlite')",
+            $content
+        );
+    }
+
     public function testGetDefaultPortForMySQL(): void
     {
         $reflection = new \ReflectionClass($this->processor);

--- a/tests/Unit/CreatesDatabaseConfigTest.php
+++ b/tests/Unit/CreatesDatabaseConfigTest.php
@@ -73,7 +73,7 @@ class CreatesDatabaseConfigTest extends TestCase
         $this->assertStringContainsString("'engine' => env('DB_ENGINE', '')", $content);
     }
 
-    public function testGenerateConfigContentForSqliteUsesCoreDatabaseDefaultPath(): void
+    public function testGenerateConfigContentForSqliteStoresFileInsideCoreDatabase(): void
     {
         $reflection = new \ReflectionClass($this->processor);
         $method = $reflection->getMethod('generateConfigContent');

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -121,6 +121,28 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->removeTempDir($projectPath);
     }
 
+    public function testWriteCoreCustomEnvStoresOnlySqliteFileNameInsideCoreDatabase(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $projectPath = $this->makeTempProjectDir();
+        @mkdir($projectPath . '/core/custom', 0755, true);
+
+        $cmd->writeCoreCustomEnvPublic($projectPath, [
+            'database' => [
+                'type' => 'sqlite',
+                'name' => 'nested/custom.sqlite',
+                'prefix' => 'evo_',
+            ],
+        ]);
+
+        $env = (string) file_get_contents($projectPath . '/core/custom/.env');
+        $expected = 'DB_DATABASE="' . $projectPath . '/core/database/custom.sqlite"' . "\n";
+        $this->assertStringContainsString($expected, $env);
+
+        $this->removeTempDir($projectPath);
+    }
+
     public function testApplyManagerDirectoryRenamesManagerFolder(): void
     {
         $cmd = $this->makeCommand();

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -99,6 +99,28 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->removeTempDir($projectPath);
     }
 
+    public function testWriteCoreCustomEnvWritesSqlitePathInsideCoreDatabase(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $projectPath = $this->makeTempProjectDir();
+        @mkdir($projectPath . '/core/custom', 0755, true);
+
+        $cmd->writeCoreCustomEnvPublic($projectPath, [
+            'database' => [
+                'type' => 'sqlite',
+                'name' => 'database.sqlite',
+                'prefix' => 'evo_',
+            ],
+        ]);
+
+        $env = (string) file_get_contents($projectPath . '/core/custom/.env');
+        $expected = 'DB_DATABASE="' . $projectPath . '/core/database/database.sqlite"' . "\n";
+        $this->assertStringContainsString($expected, $env);
+
+        $this->removeTempDir($projectPath);
+    }
+
     public function testApplyManagerDirectoryRenamesManagerFolder(): void
     {
         $cmd = $this->makeCommand();
@@ -170,4 +192,3 @@ final class TestableInstallCommand extends InstallCommand
         $this->applyManagerDirectory($projectPath, $options);
     }
 }
-


### PR DESCRIPTION
## Summary
- move the default SQLite path from the project root to `core/database/database.sqlite`
- normalize relative SQLite paths so plain names like `database.sqlite` resolve inside `core/database`
- update the Go TUI/CLI default prompt, generated DB config, runtime DB creation path, and README examples
- add regression coverage for generated config content and `.env` writing

## Verification
- `vendor-php/bin/phpunit tests/Unit/CreatesDatabaseConfigTest.php tests/Unit/InstallCommandAdminDirectoryTest.php`
- `go test ./internal/engine/install`