### PR TITLE
Add bundled and legacy sources to installer extras flow

### DIFF
--- a/internal/domain/extras.go
+++ b/internal/domain/extras.go
@@ -18,16 +18,37 @@ const (
 )
 
 type ExtrasPackage struct {
+	ID                 string   `json:"id,omitempty"`
 	Name               string   `json:"name"`
 	Version            string   `json:"version"`
 	Versions           []string `json:"versions,omitempty"`
 	Description        string   `json:"description"`
 	DefaultInstallMode string   `json:"defaultInstallMode"`
 	DefaultBranch      string   `json:"defaultBranch,omitempty"`
+	Source             string   `json:"source,omitempty"`
+	Section            string   `json:"section,omitempty"`
+	Kind               string   `json:"kind,omitempty"`
+	InstallMode        string   `json:"installMode,omitempty"`
+	Preselected        bool     `json:"preselected,omitempty"`
+	Path               string   `json:"path,omitempty"`
+	Properties         string   `json:"properties,omitempty"`
+	Events             string   `json:"events,omitempty"`
+	GUID               string   `json:"guid,omitempty"`
+	Category           string   `json:"category,omitempty"`
+	LegacyNames        string   `json:"legacyNames,omitempty"`
+	Disabled           bool     `json:"disabled,omitempty"`
+	ShareParams        int      `json:"shareParams,omitempty"`
+	Icon               string   `json:"icon,omitempty"`
+	DownloadURL        string   `json:"downloadUrl,omitempty"`
+	Dependencies       string   `json:"dependencies,omitempty"`
+	Deprecated         bool     `json:"deprecated,omitempty"`
+	Method             string   `json:"method,omitempty"`
 }
 
 type ExtrasSelection struct {
+	ID      string
 	Name    string
+	Source  string
 	Version string
 }
 

--- a/internal/domain/extras.go
+++ b/internal/domain/extras.go
@@ -66,6 +66,7 @@ type ExtrasItemDetail struct {
 type ExtrasState struct {
 	Active       bool
 	Stage        ExtrasStage
+	ProjectPath  string
 	Packages     []ExtrasPackage
 	Selections   []ExtrasSelection
 	Results      []ExtrasItemResult

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -1892,6 +1892,15 @@ try {
     if ($name !== ":memory:" && !str_starts_with($name, "file:") && !preg_match('/^(\/|[A-Za-z]:[\\\\\\/])/', $name)) {
       $name = "core/database/" . basename(str_replace("\\", "/", $name));
     }
+    if ($name !== ":memory:" && !str_starts_with($name, "file:")) {
+      $dir = dirname($name);
+      if ($dir !== "" && $dir !== "." && !is_dir($dir)) {
+        @mkdir($dir, 0755, true);
+      }
+      if (!file_exists($name)) {
+        @touch($name);
+      }
+    }
     new \PDO("sqlite:".$name, null, null, $timeout);
     echo json_encode(["ok"=>true]); exit(0);
   }

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -1830,9 +1830,9 @@ func dbDriverQuestionOptions(status domain.SystemStatus) []domain.QuestionOption
 	// If we don't have system status yet, don't block the user.
 	if len(status.Items) == 0 {
 		return []domain.QuestionOption{
+			{ID: "sqlite", Label: "SQLite", Enabled: true},
 			{ID: "mysql", Label: "MySQL or MariaDB", Enabled: true},
 			{ID: "pgsql", Label: "PostgreSQL", Enabled: true},
-			{ID: "sqlite", Label: "SQLite", Enabled: true},
 			{ID: "sqlsrv", Label: "SQL Server", Enabled: true},
 		}
 	}
@@ -1841,9 +1841,9 @@ func dbDriverQuestionOptions(status domain.SystemStatus) []domain.QuestionOption
 	pdoOK := ok && pdoLevel == domain.StatusOK
 
 	return []domain.QuestionOption{
+		dbDriverOption(status, pdoOK, "sqlite", "SQLite", "pdo_sqlite"),
 		dbDriverOption(status, pdoOK, "mysql", "MySQL or MariaDB", "pdo_mysql"),
 		dbDriverOption(status, pdoOK, "pgsql", "PostgreSQL", "pdo_pgsql"),
-		dbDriverOption(status, pdoOK, "sqlite", "SQLite", "pdo_sqlite"),
 		dbDriverOption(status, pdoOK, "sqlsrv", "SQL Server", "pdo_sqlsrv"),
 	}
 }

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -991,7 +991,41 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 		}
 
 		e.maybeRunExtras(ctx, emit, actions, workDir)
+		e.cleanupExtrasRuntimeArtifacts(emit, workDir)
 	}()
+}
+
+func (e *Engine) cleanupExtrasRuntimeArtifacts(emit func(domain.Event) bool, workDir string) {
+	cacheDir := filepath.Join(absDir(workDir), extrasRuntimeCacheDir)
+	if _, err := os.Stat(cacheDir); err != nil {
+		return
+	}
+	if err := os.RemoveAll(cacheDir); err != nil {
+		if emit != nil {
+			_ = emit(domain.Event{
+				Type:     domain.EventWarning,
+				StepID:   extrasStepID,
+				Source:   "extras",
+				Severity: domain.SeverityWarn,
+				Payload: domain.LogPayload{
+					Message: "Failed to remove installer extras runtime cache.",
+					Fields:  map[string]string{"error": err.Error()},
+				},
+			})
+		}
+		return
+	}
+	if emit != nil {
+		_ = emit(domain.Event{
+			Type:     domain.EventLog,
+			StepID:   extrasStepID,
+			Source:   "extras",
+			Severity: domain.SeverityInfo,
+			Payload: domain.LogPayload{
+				Message: "Removed installer extras runtime cache.",
+			},
+		})
+	}
 }
 
 type phpNewOptions struct {

--- a/internal/engine/install/extras.go
+++ b/internal/engine/install/extras.go
@@ -61,6 +61,20 @@ func sanitizeExtrasPackages(pkgs []domain.ExtrasPackage) []domain.ExtrasPackage 
 		p.Description = strings.TrimSpace(p.Description)
 		p.DefaultInstallMode = strings.TrimSpace(p.DefaultInstallMode)
 		p.DefaultBranch = strings.TrimSpace(p.DefaultBranch)
+		p.Source = strings.TrimSpace(p.Source)
+		p.Section = strings.TrimSpace(p.Section)
+		p.Kind = strings.TrimSpace(p.Kind)
+		p.InstallMode = strings.TrimSpace(p.InstallMode)
+		p.Path = strings.TrimSpace(p.Path)
+		p.Properties = strings.TrimSpace(p.Properties)
+		p.Events = strings.TrimSpace(p.Events)
+		p.GUID = strings.TrimSpace(p.GUID)
+		p.Category = strings.TrimSpace(p.Category)
+		p.LegacyNames = strings.TrimSpace(p.LegacyNames)
+		p.Icon = strings.TrimSpace(p.Icon)
+		p.DownloadURL = strings.TrimSpace(p.DownloadURL)
+		p.Dependencies = strings.TrimSpace(p.Dependencies)
+		p.Method = strings.TrimSpace(p.Method)
 		if len(p.Versions) > 0 {
 			seen := map[string]struct{}{}
 			clean := make([]string, 0, len(p.Versions))
@@ -76,6 +90,18 @@ func sanitizeExtrasPackages(pkgs []domain.ExtrasPackage) []domain.ExtrasPackage 
 				clean = append(clean, v)
 			}
 			p.Versions = clean
+		}
+		if p.Source == "" {
+			p.Source = "managed"
+		}
+		if p.Section == "" {
+			p.Section = "Managed extras"
+		}
+		if p.InstallMode == "" {
+			p.InstallMode = "managed-artisan"
+		}
+		if p.ID == "" {
+			p.ID = p.Source + ":" + p.Name
 		}
 		out = append(out, p)
 	}

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -13,11 +13,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evolution-cms/installer/internal/domain"
 )
 
 const legacyStoreCatalogURL = "https://extras.evo.im/get.php"
+const extrasRuntimeCacheDir = "core/.evo-installer-runtime"
 
 type extrasDocblock struct {
 	Name        string
@@ -136,7 +138,16 @@ func sortExtrasPackages(pkgs []domain.ExtrasPackage) {
 }
 
 func loadBundledInlineExtras(workDir string) ([]domain.ExtrasPackage, error) {
-	baseDir := filepath.Join(absDir(workDir), "install", "assets")
+	projectDir := absDir(workDir)
+	baseDir := filepath.Join(projectDir, "install", "assets")
+	pathPrefix := filepath.Join("install", "assets")
+	if _, err := os.Stat(baseDir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		baseDir = filepath.Join(projectDir, extrasRuntimeCacheDir, "install", "assets")
+		pathPrefix = filepath.Join(extrasRuntimeCacheDir, "install", "assets")
+	}
 	specs := []struct {
 		subdir  string
 		kind    string
@@ -180,7 +191,7 @@ func loadBundledInlineExtras(workDir string) ([]domain.ExtrasPackage, error) {
 				Kind:               spec.kind,
 				InstallMode:        "bundled-inline",
 				Preselected:        strings.Contains(installset, "base"),
-				Path:               filepath.ToSlash(filepath.Join("install", "assets", spec.subdir, entry.Name())),
+				Path:               filepath.ToSlash(filepath.Join(pathPrefix, spec.subdir, entry.Name())),
 				Properties:         strings.TrimSpace(doc.Tags["properties"]),
 				Events:             strings.TrimSpace(doc.Tags["events"]),
 				GUID:               strings.TrimSpace(doc.Tags["guid"]),
@@ -276,8 +287,11 @@ func loadLegacyStoreCatalog(ctx context.Context) ([]domain.ExtrasPackage, error)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "EvolutionCMS-Installer/Go")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -1,0 +1,360 @@
+package install
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/evolution-cms/installer/internal/domain"
+)
+
+const legacyStoreCatalogURL = "https://extras.evo.im/get.php"
+
+type extrasDocblock struct {
+	Name        string
+	Description string
+	Tags        map[string]string
+}
+
+type legacyStoreStartResponse struct {
+	Version     string                             `json:"version"`
+	Category    []legacyStoreCategory              `json:"category"`
+	AllCategory map[string][]legacyStoreCatalogRaw `json:"allcategory"`
+}
+
+type legacyStoreCategory struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type legacyStoreCatalogRaw struct {
+	ID           string              `json:"id"`
+	URL          legacyStoreURLField `json:"url"`
+	Method       string              `json:"method"`
+	Type         string              `json:"type"`
+	Downloads    string              `json:"downloads"`
+	Dependencies string              `json:"dependencies"`
+	Description  string              `json:"description"`
+	Title        string              `json:"title"`
+	Author       string              `json:"author"`
+	NameInMODX   string              `json:"name_in_modx"`
+	Deprecated   string              `json:"deprecated"`
+	Image        string              `json:"image"`
+	CartImage    string              `json:"cartimage"`
+}
+
+type legacyStoreURLField struct {
+	FieldValue []legacyStoreVersion `json:"fieldValue"`
+}
+
+type legacyStoreVersion struct {
+	File    string `json:"file"`
+	Version string `json:"version"`
+	Date    string `json:"date"`
+}
+
+func loadAllExtrasCatalogs(ctx context.Context, workDir, token string) ([]domain.ExtrasPackage, []domain.ExtrasSelection, []string, error) {
+	coreDir, warn, err := checkExtrasPrereqs(ctx, workDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pkgs := make([]domain.ExtrasPackage, 0, 64)
+	warnings := []string{}
+	if warn != "" {
+		warnings = append(warnings, warn)
+	}
+
+	managed, err := fetchExtrasList(ctx, coreDir, token)
+	if err != nil {
+		warnings = append(warnings, "Managed extras unavailable: "+err.Error())
+	} else {
+		pkgs = append(pkgs, managed...)
+	}
+
+	bundled, err := loadBundledInlineExtras(workDir)
+	if err != nil {
+		warnings = append(warnings, "Bundled defaults unavailable: "+err.Error())
+	} else {
+		pkgs = append(pkgs, bundled...)
+	}
+
+	legacy, err := loadLegacyStoreCatalog(ctx)
+	if err != nil {
+		warnings = append(warnings, "Legacy Store catalog unavailable: "+err.Error())
+	} else {
+		pkgs = append(pkgs, legacy...)
+	}
+
+	sortExtrasPackages(pkgs)
+	defaults := defaultExtrasSelections(pkgs)
+	return pkgs, defaults, warnings, nil
+}
+
+func defaultExtrasSelections(pkgs []domain.ExtrasPackage) []domain.ExtrasSelection {
+	out := make([]domain.ExtrasSelection, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if !pkg.Preselected {
+			continue
+		}
+		out = append(out, domain.ExtrasSelection{
+			ID:      pkg.ID,
+			Name:    pkg.Name,
+			Source:  pkg.Source,
+			Version: strings.TrimSpace(defaultExtrasVersion(pkg)),
+		})
+	}
+	return out
+}
+
+func sortExtrasPackages(pkgs []domain.ExtrasPackage) {
+	order := map[string]int{
+		"bundled-inline": 0,
+		"managed":        1,
+		"legacy-store":   2,
+	}
+	sort.SliceStable(pkgs, func(i, j int) bool {
+		oi := order[pkgs[i].Source]
+		oj := order[pkgs[j].Source]
+		if oi != oj {
+			return oi < oj
+		}
+		if pkgs[i].Section != pkgs[j].Section {
+			return pkgs[i].Section < pkgs[j].Section
+		}
+		return strings.ToLower(pkgs[i].Name) < strings.ToLower(pkgs[j].Name)
+	})
+}
+
+func loadBundledInlineExtras(workDir string) ([]domain.ExtrasPackage, error) {
+	baseDir := filepath.Join(absDir(workDir), "install", "assets")
+	specs := []struct {
+		subdir  string
+		kind    string
+		section string
+	}{
+		{subdir: "plugins", kind: "plugin", section: "Bundled defaults"},
+		{subdir: "modules", kind: "module", section: "Bundled defaults"},
+	}
+
+	pkgs := make([]domain.ExtrasPackage, 0, 12)
+	for _, spec := range specs {
+		dir := filepath.Join(baseDir, spec.subdir)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tpl") {
+				continue
+			}
+			doc, err := parseExtrasDocblockFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			name := strings.TrimSpace(doc.Name)
+			if name == "" {
+				continue
+			}
+			installset := strings.ToLower(strings.TrimSpace(doc.Tags["installset"]))
+			pkg := domain.ExtrasPackage{
+				ID:                 "bundled-inline:" + strings.ToLower(name),
+				Name:               name,
+				Version:            strings.TrimSpace(doc.Tags["version"]),
+				Description:        strings.TrimSpace(doc.Description),
+				DefaultInstallMode: "bundled-inline",
+				Source:             "bundled-inline",
+				Section:            spec.section,
+				Kind:               spec.kind,
+				InstallMode:        "bundled-inline",
+				Preselected:        strings.Contains(installset, "base"),
+				Path:               filepath.ToSlash(filepath.Join("install", "assets", spec.subdir, entry.Name())),
+				Properties:         strings.TrimSpace(doc.Tags["properties"]),
+				Events:             strings.TrimSpace(doc.Tags["events"]),
+				GUID:               strings.TrimSpace(doc.Tags["guid"]),
+				Category:           strings.TrimSpace(doc.Tags["modx_category"]),
+				LegacyNames:        strings.TrimSpace(doc.Tags["legacy_names"]),
+				Method:             "inline",
+			}
+			if disabled := strings.TrimSpace(doc.Tags["disabled"]); disabled != "" {
+				pkg.Disabled = disabled == "1" || strings.EqualFold(disabled, "true")
+			}
+			if share := strings.TrimSpace(doc.Tags["shareparams"]); share != "" {
+				if n, err := strconv.Atoi(share); err == nil {
+					pkg.ShareParams = n
+				}
+			}
+			if icon := strings.TrimSpace(doc.Tags["icon"]); icon != "" {
+				pkg.Icon = icon
+			}
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs, nil
+}
+
+func parseExtrasDocblockFile(path string) (extrasDocblock, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return extrasDocblock{}, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	doc := extrasDocblock{Tags: map[string]string{}}
+	inDocblock := false
+	foundName := false
+	foundDesc := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !inDocblock {
+			if strings.Contains(line, "/**") {
+				inDocblock = true
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "*/") {
+			break
+		}
+		if !strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(trimmed, "*"))
+		if body == "" {
+			continue
+		}
+		if strings.HasPrefix(body, "@") {
+			tagLine := body[1:]
+			tag, value, _ := strings.Cut(tagLine, " ")
+			tag = strings.TrimSpace(tag)
+			value = strings.TrimSpace(value)
+			if tag == "internal" && strings.HasPrefix(value, "@") {
+				tagLine = value[1:]
+				tag, value, _ = strings.Cut(tagLine, " ")
+				tag = strings.TrimSpace(tag)
+				value = strings.TrimSpace(value)
+			}
+			if tag != "" && value != "" {
+				doc.Tags[tag] = value
+			}
+			continue
+		}
+		if !foundName {
+			doc.Name = body
+			foundName = true
+			continue
+		}
+		if !foundDesc {
+			doc.Description = body
+			foundDesc = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return extrasDocblock{}, err
+	}
+	return doc, nil
+}
+
+func loadLegacyStoreCatalog(ctx context.Context) ([]domain.ExtrasPackage, error) {
+	body := bytes.NewBufferString("get=start&user=1&lang=en")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, legacyStoreCatalogURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %s", resp.Status)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	return parseLegacyStoreCatalogJSON(raw)
+}
+
+func parseLegacyStoreCatalogJSON(raw []byte) ([]domain.ExtrasPackage, error) {
+	var payload legacyStoreStartResponse
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+
+	categories := map[string]string{}
+	for _, cat := range payload.Category {
+		if cat.ID != "" {
+			categories[cat.ID] = strings.TrimSpace(cat.Title)
+		}
+	}
+
+	out := make([]domain.ExtrasPackage, 0, 256)
+	for categoryID, items := range payload.AllCategory {
+		section := strings.TrimSpace(categories[categoryID])
+		if section == "" {
+			section = "Legacy Store"
+		}
+		for _, item := range items {
+			name := strings.TrimSpace(item.NameInMODX)
+			if name == "" {
+				name = strings.TrimSpace(item.Title)
+			}
+			if name == "" {
+				continue
+			}
+
+			versions := make([]string, 0, len(item.URL.FieldValue))
+			downloadURL := ""
+			version := ""
+			for _, candidate := range item.URL.FieldValue {
+				v := strings.TrimSpace(candidate.Version)
+				u := strings.TrimSpace(candidate.File)
+				if v != "" {
+					versions = append(versions, v)
+				}
+				if downloadURL == "" && u != "" {
+					downloadURL = u
+				}
+				if version == "" && v != "" {
+					version = v
+				}
+			}
+
+			out = append(out, domain.ExtrasPackage{
+				ID:                 "legacy-store:" + strings.TrimSpace(item.ID),
+				Name:               name,
+				Version:            version,
+				Versions:           versions,
+				Description:        strings.TrimSpace(item.Description),
+				DefaultInstallMode: "legacy-store-zip",
+				Source:             "legacy-store",
+				Section:            "Legacy Store - " + section,
+				Kind:               strings.TrimSpace(item.Type),
+				InstallMode:        "legacy-store-zip",
+				DownloadURL:        downloadURL,
+				Dependencies:       strings.TrimSpace(item.Dependencies),
+				Deprecated:         strings.TrimSpace(item.Deprecated) == "1",
+				Method:             strings.TrimSpace(item.Method),
+			})
+		}
+	}
+	return sanitizeExtrasPackages(out), nil
+}

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -745,6 +745,27 @@ func emitExtrasSkippedSummary(emit func(domain.Event) bool) {
 
 func detectExtrasFailure(out string) string {
 	lines := strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n")
+
+	priorityHints := []string{
+		"sqlstate[",
+		"thrown in ",
+	}
+	for _, raw := range lines {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		lower := strings.ToLower(raw)
+		for _, hint := range priorityHints {
+			if strings.Contains(lower, hint) {
+				return raw
+			}
+		}
+		if strings.HasPrefix(lower, "fatal:") || strings.HasPrefix(lower, "error:") {
+			return raw
+		}
+	}
+
 	hints := []string{
 		"the limit that is provided for free use of github has been exceeded",
 		"github api rate limit exceeded",
@@ -758,6 +779,7 @@ func detectExtrasFailure(out string) string {
 		"could not resolve host",
 		"failed to download",
 		"failed to open stream",
+		"stack trace:",
 		"package operations: 0 installs, 0 updates, 0 removals",
 	}
 
@@ -776,6 +798,9 @@ func detectExtrasFailure(out string) string {
 			}
 		}
 		if strings.HasPrefix(lower, "fatal:") || strings.HasPrefix(lower, "error:") {
+			return raw
+		}
+		if strings.HasSuffix(lower, " fail") {
 			return raw
 		}
 		if strings.Contains(lower, "exception") {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -112,16 +112,27 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 		Source:   "extras",
 		Severity: domain.SeverityInfo,
 		Payload: domain.LogPayload{
-			Message: "Fetching extras list...",
+			Message: "Fetching extras catalogs...",
 		},
 	})
 
 	token := strings.TrimSpace(e.opt.GithubPat)
-	pkgs, err := fetchExtrasList(ctx, coreDir, token)
+	pkgs, defaults, warnings, err := loadAllExtrasCatalogs(ctx, workDir, token)
+	for _, msg := range warnings {
+		_ = emit(domain.Event{
+			Type:     domain.EventWarning,
+			StepID:   extrasStepID,
+			Source:   "extras",
+			Severity: domain.SeverityWarn,
+			Payload: domain.LogPayload{
+				Message: msg,
+			},
+		})
+	}
 	if err != nil || len(pkgs) == 0 {
-		msg := "Extras list unavailable."
+		msg := "Extras catalogs unavailable."
 		if err != nil {
-			msg = "Extras list unavailable: " + err.Error()
+			msg = "Extras catalogs unavailable: " + err.Error()
 		}
 		_ = emit(domain.Event{
 			Type:     domain.EventWarning,
@@ -145,9 +156,10 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			Source:   "extras",
 			Severity: domain.SeverityInfo,
 			Payload: domain.ExtrasState{
-				Active:   true,
-				Stage:    domain.ExtrasStageSelect,
-				Packages: pkgs,
+				Active:     true,
+				Stage:      domain.ExtrasStageSelect,
+				Packages:   pkgs,
+				Selections: defaults,
 			},
 		})
 	}
@@ -237,6 +249,12 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 	})
 
 	results := make([]domain.ExtrasItemResult, 0, len(selections)+2)
+	pkgByID := map[string]domain.ExtrasPackage{}
+	for _, pkg := range pkgs {
+		if id := strings.TrimSpace(pkg.ID); id != "" {
+			pkgByID[id] = pkg
+		}
+	}
 	for _, sel := range selections {
 		results = append(results, domain.ExtrasItemResult{
 			Name:   formatExtrasSelectionLabel(sel),
@@ -276,12 +294,7 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			Payload:  state,
 		})
 
-		args := []string{"extras", "extras", sel.Name}
-		if strings.TrimSpace(sel.Version) != "" {
-			args = append(args, sel.Version)
-		}
-		args = append(args, "--no-ansi", "--no-interaction")
-		out, err := runArtisanCommand(ctx, coreDir, token, args)
+		out, err := runExtrasSelection(ctx, coreDir, token, pkgByID, sel)
 		emitExtrasOutputLogs(emit, extrasStepID, label, out)
 		message := lastNonEmptyLine(out)
 		detectedErr := detectExtrasFailure(out)
@@ -466,11 +479,11 @@ func selectionsFromValues(values []string) []domain.ExtrasSelection {
 		if v == "" {
 			continue
 		}
-		name, version := splitSelectionValue(v)
-		if name == "" {
+		id, version := splitSelectionValue(v)
+		if id == "" {
 			continue
 		}
-		out = append(out, domain.ExtrasSelection{Name: name, Version: version})
+		out = append(out, domain.ExtrasSelection{ID: id, Version: version})
 	}
 	return out
 }
@@ -489,48 +502,118 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		return nil
 	}
 	allowed := map[string]struct{}{}
+	pkgByID := map[string]domain.ExtrasPackage{}
 	pkgByName := map[string]domain.ExtrasPackage{}
 	for _, p := range pkgs {
+		if p.ID != "" {
+			allowed[p.ID] = struct{}{}
+			pkgByID[p.ID] = p
+		}
 		if p.Name != "" {
-			allowed[p.Name] = struct{}{}
-			pkgByName[p.Name] = p
+			pkgByName[strings.ToLower(p.Name)] = p
 		}
 	}
 	out := make([]domain.ExtrasSelection, 0, len(selections))
 	seen := map[string]int{}
 	for _, sel := range selections {
-		name := strings.TrimSpace(sel.Name)
-		if name == "" {
+		id := strings.TrimSpace(sel.ID)
+		pkg := domain.ExtrasPackage{}
+		var ok bool
+		if id != "" {
+			pkg, ok = pkgByID[id]
+		}
+		if !ok {
+			name := strings.ToLower(strings.TrimSpace(sel.Name))
+			if name == "" {
+				continue
+			}
+			pkg, ok = pkgByName[name]
+		}
+		if !ok {
 			continue
 		}
-		if _, ok := allowed[name]; !ok {
+		id = strings.TrimSpace(pkg.ID)
+		if _, ok := allowed[id]; !ok {
 			continue
 		}
 		version := strings.TrimSpace(sel.Version)
 		if version == "" {
-			if pkg, ok := pkgByName[name]; ok {
-				version = strings.TrimSpace(defaultExtrasVersion(pkg))
-			}
+			version = strings.TrimSpace(defaultExtrasVersion(pkg))
 		}
-		if idx, ok := seen[name]; ok {
+		if idx, ok := seen[id]; ok {
 			if out[idx].Version == "" && version != "" {
 				out[idx].Version = version
 			}
 			continue
 		}
-		seen[name] = len(out)
-		out = append(out, domain.ExtrasSelection{Name: name, Version: version})
+		seen[id] = len(out)
+		out = append(out, domain.ExtrasSelection{
+			ID:      id,
+			Name:    pkg.Name,
+			Source:  pkg.Source,
+			Version: version,
+		})
 	}
 	return out
 }
 
 func formatExtrasSelectionLabel(sel domain.ExtrasSelection) string {
 	name := strings.TrimSpace(sel.Name)
-	version := strings.TrimSpace(sel.Version)
-	if version == "" {
-		return name
+	if name == "" {
+		name = strings.TrimSpace(sel.ID)
 	}
-	return name + "@" + version
+	version := strings.TrimSpace(sel.Version)
+	prefix := ""
+	switch strings.TrimSpace(sel.Source) {
+	case "bundled-inline":
+		prefix = "[bundled] "
+	case "legacy-store":
+		prefix = "[legacy] "
+	}
+	if version == "" {
+		return prefix + name
+	}
+	return prefix + name + "@" + version
+}
+
+func runExtrasSelection(ctx context.Context, coreDir string, token string, pkgByID map[string]domain.ExtrasPackage, sel domain.ExtrasSelection) (string, error) {
+	pkg, ok := pkgByID[strings.TrimSpace(sel.ID)]
+	if !ok {
+		args := []string{"extras", "extras", sel.Name}
+		if strings.TrimSpace(sel.Version) != "" {
+			args = append(args, sel.Version)
+		}
+		args = append(args, "--no-ansi", "--no-interaction")
+		return runArtisanCommand(ctx, coreDir, token, args)
+	}
+
+	switch pkg.InstallMode {
+	case "bundled-inline":
+		payload := map[string]any{
+			"items": []domain.ExtrasPackage{pkg},
+		}
+		return runExtrasHelper(ctx, coreDir, "bundled-inline", payload)
+	case "legacy-store-zip":
+		if strings.TrimSpace(pkg.DownloadURL) == "" {
+			return "", fmt.Errorf("legacy store package is missing a download URL")
+		}
+		payload := map[string]any{
+			"item": map[string]any{
+				"name":         pkg.Name,
+				"downloadUrl":  pkg.DownloadURL,
+				"dependencies": pkg.Dependencies,
+			},
+		}
+		return runExtrasHelper(ctx, coreDir, "legacy-store", payload)
+	default:
+		args := []string{"extras", "extras", pkg.Name}
+		version := strings.TrimSpace(sel.Version)
+		if version != "" {
+			args = append(args, version)
+		}
+		args = append(args, "--no-ansi", "--no-interaction")
+		return runArtisanCommand(ctx, coreDir, token, args)
+	}
 }
 
 func defaultExtrasVersion(pkg domain.ExtrasPackage) string {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -263,11 +263,12 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 	}
 
 	state := domain.ExtrasState{
-		Active:     true,
-		Stage:      domain.ExtrasStageProgress,
-		Selections: selections,
-		Results:    results,
-		Total:      len(selections),
+		Active:      true,
+		Stage:       domain.ExtrasStageProgress,
+		ProjectPath: workDir,
+		Selections:  selections,
+		Results:     results,
+		Total:       len(selections),
 	}
 	_ = emit(domain.Event{
 		Type:     domain.EventExtras,

--- a/internal/engine/install/extras_helper.go
+++ b/internal/engine/install/extras_helper.go
@@ -1,0 +1,43 @@
+package install
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+//go:embed extras_helper.php
+var extrasHelperPHP string
+
+func runExtrasHelper(ctx context.Context, coreDir string, mode string, payload any) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "evo-installer-extras-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	scriptPath := filepath.Join(tmpDir, "extras_helper.php")
+	if err := os.WriteFile(scriptPath, []byte(extrasHelperPHP), 0o600); err != nil {
+		return "", err
+	}
+
+	payloadPath := filepath.Join(tmpDir, "payload.json")
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(payloadPath, raw, 0o600); err != nil {
+		return "", err
+	}
+
+	projectPath := filepath.Dir(absDir(coreDir))
+	cmd := exec.CommandContext(ctx, "php", scriptPath, projectPath, mode, payloadPath)
+	cmd.Dir = projectPath
+	cmd.Env = append([]string(nil), os.Environ()...)
+	cmd.Env = append(cmd.Env, "CI=1")
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -33,9 +33,11 @@ function helper_bootstrap(string $projectPath): void
 {
     defined('EVO_API_MODE') || define('EVO_API_MODE', true);
     defined('IN_INSTALL_MODE') || define('IN_INSTALL_MODE', true);
+    defined('IN_MANAGER_MODE') || define('IN_MANAGER_MODE', false);
     defined('EVO_CLI') || define('EVO_CLI', true);
     defined('EVO_BASE_PATH') || define('EVO_BASE_PATH', rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
     defined('EVO_CORE_PATH') || define('EVO_CORE_PATH', EVO_BASE_PATH . 'core' . DIRECTORY_SEPARATOR);
+    defined('EVO_BASE_URL') || define('EVO_BASE_URL', '/');
     defined('EVO_SITE_URL') || define('EVO_SITE_URL', '/');
 
     chdir($projectPath);
@@ -54,6 +56,11 @@ function helper_bootstrap(string $projectPath): void
     if (!is_file($installFunctions)) {
         helper_fail("install/src/functions.php is not available.");
     }
+
+    if (function_exists('evo')) {
+        evo()->getDatabase();
+    }
+
     require_once $installFunctions;
 }
 

--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -83,6 +83,95 @@ function helper_chunk_code(string $path): string
     return helper_remove_installer_docblock((string) file_get_contents($path));
 }
 
+function helper_parse_csv(string $value): array
+{
+    return array_values(array_filter(array_map('trim', explode(',', $value)), static function ($value) {
+        return $value !== '';
+    }));
+}
+
+function helper_install_template(array $item, string $path): void
+{
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $locked = !empty($item['locked']) ? 1 : 0;
+    $code = helper_chunk_code($path);
+    $template = \EvolutionCMS\Models\SiteTemplate::query()->where('templatename', $name)->first();
+    if ($template !== null) {
+        \EvolutionCMS\Models\SiteTemplate::query()->where('templatename', $name)->update([
+            'content' => $code,
+            'description' => $desc,
+            'category' => $category,
+            'locked' => $locked,
+        ]);
+    } else {
+        \EvolutionCMS\Models\SiteTemplate::query()->create([
+            'templatename' => $name,
+            'content' => $code,
+            'description' => $desc,
+            'category' => $category,
+            'locked' => $locked,
+        ]);
+    }
+
+    helper_log("Installed template: {$name}");
+}
+
+function helper_install_tv(array $item, string $path): void
+{
+    unset($path);
+
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $caption = trim((string) ($item['caption'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $locked = !empty($item['locked']) ? 1 : 0;
+    $assignments = $item['assignments'] ?? [];
+    if (!is_array($assignments)) {
+        $assignments = helper_parse_csv((string) $assignments);
+    }
+
+    $tv = \EvolutionCMS\Models\SiteTmplvar::query()->updateOrCreate(
+        ['name' => $name],
+        [
+            'type' => trim((string) ($item['inputType'] ?? '')),
+            'caption' => $caption,
+            'description' => $desc,
+            'category' => $category,
+            'locked' => $locked,
+            'elements' => trim((string) ($item['inputOptions'] ?? '')),
+            'display' => trim((string) ($item['outputWidget'] ?? '')),
+            'display_params' => trim((string) ($item['outputWidgetParams'] ?? '')),
+            'default_text' => trim((string) ($item['inputDefault'] ?? '')),
+        ]
+    );
+
+    \EvolutionCMS\Models\SiteTmplvarTemplate::query()->where('tmplvarid', $tv->getKey())->delete();
+    foreach ($assignments as $assignment) {
+        $templateName = trim((string) $assignment);
+        if ($templateName === '') {
+            continue;
+        }
+        $template = \EvolutionCMS\Models\SiteTemplate::query()->where('templatename', $templateName)->first();
+        if ($template === null) {
+            continue;
+        }
+        \EvolutionCMS\Models\SiteTmplvarTemplate::query()->firstOrCreate([
+            'tmplvarid' => $tv->getKey(),
+            'templateid' => $template->getKey(),
+        ]);
+    }
+
+    helper_log("Installed TV: {$name}");
+}
+
 function helper_install_plugin(array $item, string $path): void
 {
     $name = trim((string) ($item['name'] ?? ''));
@@ -276,31 +365,46 @@ function helper_install_chunk(array $item, string $path): void
     }
     $desc = trim((string) ($item['description'] ?? ''));
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $overwrite = strtolower(trim((string) ($item['overwrite'] ?? 'true')));
     $code = helper_chunk_code($path);
-    $chunk = \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $name)->first();
-    if ($chunk !== null) {
+    $chunkRecord = \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $name)->first();
+    $countNewName = 0;
+    if ($overwrite === 'false') {
+        $newName = $name . '-' . str_replace('.', '_', (string) evo()->getVersionData('version'));
+        $countNewName = \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $newName)->count();
+    }
+    $update = $chunkRecord !== null && $overwrite === 'true';
+    if ($update) {
         \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $name)->update([
             'snippet' => $code,
             'description' => $desc,
             'category' => $category,
         ]);
-    } else {
+        helper_log("Installed chunk: {$name}");
+        return;
+    }
+    if ($countNewName === 0) {
+        if ($chunkRecord !== null && $overwrite === 'false') {
+            $name = $newName;
+        }
         \EvolutionCMS\Models\SiteHtmlsnippet::query()->create([
             'name' => $name,
             'snippet' => $code,
             'description' => $desc,
             'category' => $category,
         ]);
+        helper_log("Installed chunk: {$name}");
+        return;
     }
 
-    helper_log("Installed chunk: {$name}");
+    helper_log("Skipped chunk (already exists and overwrite=false): {$name}");
 }
 
-function helper_scan_tpl_dir(string $dir, string $kind): array
+function helper_docblock_entries(string $dir): array
 {
-    $items = [];
+    $entries = [];
     if (!is_dir($dir)) {
-        return $items;
+        return $entries;
     }
     $files = scandir($dir) ?: [];
     foreach ($files as $file) {
@@ -316,22 +420,172 @@ function helper_scan_tpl_dir(string $dir, string $kind): array
         if ($version !== '') {
             $description = "<strong>{$version}</strong> {$description}";
         }
-        $items[] = [
-            'kind' => $kind,
-            'name' => trim((string) ($params['name'] ?? '')),
-            'description' => $description,
+        $entries[] = [
             'path' => $dir . DIRECTORY_SEPARATOR . $file,
+            'params' => $params,
+            'description' => $description,
+        ];
+    }
+    return $entries;
+}
+
+function helper_collect_install_assets(string $assetRoot): array
+{
+    $items = [];
+    $dependencies = [];
+    $templateNames = [];
+
+    foreach (helper_docblock_entries($assetRoot . '/templates') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $templateNames[] = $name;
+        $items[] = [
+            'kind' => 'template',
+            'name' => $name,
+            'description' => $entry['description'],
+            'path' => $entry['path'],
+            'category' => trim((string) ($params['modx_category'] ?? '')),
+            'locked' => (int) trim((string) ($params['lock_template'] ?? '0')),
+        ];
+    }
+
+    foreach (helper_docblock_entries($assetRoot . '/tvs') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $assignments = trim((string) ($params['template_assignments'] ?? ''));
+        if ($assignments === '*') {
+            $assignments = $templateNames;
+        } else {
+            $assignments = helper_parse_csv($assignments);
+        }
+        $items[] = [
+            'kind' => 'tv',
+            'name' => $name,
+            'caption' => trim((string) ($params['caption'] ?? '')),
+            'description' => $entry['description'],
+            'path' => $entry['path'],
+            'category' => trim((string) ($params['modx_category'] ?? '')),
+            'locked' => (int) trim((string) ($params['lock_tv'] ?? '0')),
+            'inputType' => trim((string) ($params['input_type'] ?? '')),
+            'inputOptions' => trim((string) ($params['input_options'] ?? '')),
+            'inputDefault' => trim((string) ($params['input_default'] ?? '')),
+            'outputWidget' => trim((string) ($params['output_widget'] ?? '')),
+            'outputWidgetParams' => trim((string) ($params['output_widget_params'] ?? '')),
+            'assignments' => $assignments,
+        ];
+    }
+
+    foreach (helper_docblock_entries($assetRoot . '/chunks') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $items[] = [
+            'kind' => 'chunk',
+            'name' => $name,
+            'description' => $entry['description'],
+            'path' => $entry['path'],
+            'category' => trim((string) ($params['modx_category'] ?? '')),
+            'overwrite' => trim((string) ($params['overwrite'] ?? 'true')),
+        ];
+    }
+
+    foreach (helper_docblock_entries($assetRoot . '/snippets') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $items[] = [
+            'kind' => 'snippet',
+            'name' => $name,
+            'description' => $entry['description'],
+            'path' => $entry['path'],
+            'properties' => trim((string) ($params['properties'] ?? '')),
+            'category' => trim((string) ($params['modx_category'] ?? '')),
+        ];
+    }
+
+    foreach (helper_docblock_entries($assetRoot . '/plugins') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $items[] = [
+            'kind' => 'plugin',
+            'name' => $name,
+            'description' => $entry['description'],
+            'path' => $entry['path'],
             'properties' => trim((string) ($params['properties'] ?? '')),
             'events' => trim((string) ($params['events'] ?? '')),
             'guid' => trim((string) ($params['guid'] ?? '')),
             'category' => trim((string) ($params['modx_category'] ?? '')),
             'legacyNames' => trim((string) ($params['legacy_names'] ?? '')),
             'disabled' => trim((string) ($params['disabled'] ?? '')) === '1',
+        ];
+    }
+
+    foreach (helper_docblock_entries($assetRoot . '/modules') as $entry) {
+        $params = $entry['params'];
+        $name = trim((string) ($params['name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+        $items[] = [
+            'kind' => 'module',
+            'name' => $name,
+            'description' => $entry['description'],
+            'path' => $entry['path'],
+            'properties' => trim((string) ($params['properties'] ?? '')),
+            'guid' => trim((string) ($params['guid'] ?? '')),
+            'category' => trim((string) ($params['modx_category'] ?? '')),
             'shareParams' => (int) trim((string) ($params['shareparams'] ?? '0')),
             'icon' => trim((string) ($params['icon'] ?? '')),
         ];
+
+        $moduleDependencies = helper_parse_csv((string) ($params['dependencies'] ?? ''));
+        foreach ($moduleDependencies as $dependency) {
+            $parts = array_map('trim', explode(':', $dependency, 2));
+            if (count($parts) !== 2 || $parts[0] === '' || $parts[1] === '') {
+                continue;
+            }
+            switch ($parts[0]) {
+                case 'template':
+                    $dependencies[] = ['module' => $name, 'kind' => 'template', 'name' => $parts[1], 'type' => 50];
+                    break;
+                case 'tv':
+                case 'tmplvar':
+                    $dependencies[] = ['module' => $name, 'kind' => 'tv', 'name' => $parts[1], 'type' => 60];
+                    break;
+                case 'chunk':
+                case 'htmlsnippet':
+                    $dependencies[] = ['module' => $name, 'kind' => 'chunk', 'name' => $parts[1], 'type' => 10];
+                    break;
+                case 'snippet':
+                    $dependencies[] = ['module' => $name, 'kind' => 'snippet', 'name' => $parts[1], 'type' => 40];
+                    break;
+                case 'plugin':
+                    $dependencies[] = ['module' => $name, 'kind' => 'plugin', 'name' => $parts[1], 'type' => 30];
+                    break;
+                case 'resource':
+                    $dependencies[] = ['module' => $name, 'kind' => 'resource', 'name' => $parts[1], 'type' => 20];
+                    break;
+            }
+        }
     }
-    return $items;
+
+    return [
+        'items' => $items,
+        'dependencies' => $dependencies,
+    ];
 }
 
 function helper_import_items(array $items): void
@@ -342,6 +596,12 @@ function helper_import_items(array $items): void
             continue;
         }
         switch ((string) ($item['kind'] ?? '')) {
+            case 'template':
+                helper_install_template($item, $path);
+                break;
+            case 'tv':
+                helper_install_tv($item, $path);
+                break;
             case 'plugin':
                 helper_install_plugin($item, $path);
                 break;
@@ -355,6 +615,69 @@ function helper_import_items(array $items): void
                 helper_install_chunk($item, $path);
                 break;
         }
+    }
+}
+
+function helper_install_module_dependencies(array $dependencies): void
+{
+    foreach ($dependencies as $dependency) {
+        $moduleName = trim((string) ($dependency['module'] ?? ''));
+        $dependencyName = trim((string) ($dependency['name'] ?? ''));
+        if ($moduleName === '' || $dependencyName === '') {
+            continue;
+        }
+
+        $module = \EvolutionCMS\Models\SiteModule::query()->where('name', $moduleName)->first();
+        if ($module === null) {
+            continue;
+        }
+
+        $resourceId = null;
+        switch ((string) ($dependency['kind'] ?? '')) {
+            case 'template':
+                $resource = \EvolutionCMS\Models\SiteTemplate::query()->where('templatename', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+            case 'tv':
+                $resource = \EvolutionCMS\Models\SiteTmplvar::query()->where('name', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+            case 'chunk':
+                $resource = \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+            case 'snippet':
+                $resource = \EvolutionCMS\Models\SiteSnippet::query()->where('name', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+            case 'plugin':
+                $resource = \EvolutionCMS\Models\SitePlugin::query()->where('name', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+            case 'resource':
+                $resource = \EvolutionCMS\Models\SiteContent::query()->where('pagetitle', $dependencyName)->first();
+                $resourceId = $resource?->getKey();
+                break;
+        }
+
+        if ($resourceId === null) {
+            continue;
+        }
+
+        \EvolutionCMS\Models\SiteModuleDepobj::query()->updateOrCreate([
+            'module' => (int) $module->getKey(),
+            'resource' => (int) $resourceId,
+            'type' => (int) ($dependency['type'] ?? 0),
+        ]);
+
+        if ((int) ($dependency['type'] ?? 0) === 30) {
+            \EvolutionCMS\Models\SitePlugin::query()->where('id', $resourceId)->update(['moduleguid' => (string) $module->guid]);
+        }
+        if ((int) ($dependency['type'] ?? 0) === 40) {
+            \EvolutionCMS\Models\SiteSnippet::query()->where('id', $resourceId)->update(['moduleguid' => (string) $module->guid]);
+        }
+
+        helper_log("Linked module dependency: {$moduleName} -> {$dependencyName}");
     }
 }
 
@@ -428,13 +751,59 @@ function helper_find_asset_root(string $baseDir): ?string
             continue;
         }
         $path = $item->getPathname();
-        if (is_dir($path . '/plugins') || is_dir($path . '/modules') || is_dir($path . '/snippets') || is_dir($path . '/chunks')) {
+        if (
+            is_dir($path . '/plugins') ||
+            is_dir($path . '/modules') ||
+            is_dir($path . '/snippets') ||
+            is_dir($path . '/chunks') ||
+            is_dir($path . '/templates') ||
+            is_dir($path . '/tvs')
+        ) {
             if (basename($path) === 'assets') {
                 return $path;
             }
         }
     }
     return null;
+}
+
+function helper_detect_legacy_install_profile(array $items, array $dependencies, string $packageRoot): string
+{
+    $kinds = [];
+    foreach ($items as $item) {
+        $kind = trim((string) ($item['kind'] ?? ''));
+        if ($kind !== '') {
+            $kinds[$kind] = true;
+        }
+    }
+    if (isset($kinds['template']) || isset($kinds['tv'])) {
+        return 'full';
+    }
+    if (count($items) > 1 || count($kinds) > 1 || count($dependencies) > 0) {
+        return 'full';
+    }
+    if (is_file($packageRoot . '/setup.sql') || is_file($packageRoot . '/setup.data.sql')) {
+        return 'full';
+    }
+    return 'fast';
+}
+
+function helper_process_sql_file(string $path): void
+{
+    $parserPath = EVO_BASE_PATH . 'assets/modules/store/installer/sqlParser.class.php';
+    if (!is_file($parserPath)) {
+        helper_fail('Legacy SQL payload detected, but SqlParser is not available in the project.');
+    }
+    require_once $parserPath;
+    $sqlParser = new SqlParser();
+    $sqlParser->mode = 'upd';
+    $sqlParser->ignoreDuplicateErrors = true;
+    $sqlParser->process($path);
+    if (!empty($sqlParser->installFailed)) {
+        $error = $sqlParser->mysqlErrors[0]['error'] ?? 'unknown SQL import error';
+        helper_fail('Legacy package SQL import failed: ' . $error);
+    }
+    helper_log('Applied legacy SQL payload: ' . basename($path));
 }
 
 function helper_install_legacy_store_package(string $projectPath, array $item): void
@@ -460,28 +829,35 @@ function helper_install_legacy_store_package(string $projectPath, array $item): 
 
     $packageRoot = helper_find_package_root($extractDir);
     helper_recursive_copy($packageRoot, $projectPath);
+    $setupSql = $packageRoot . '/setup.sql';
+    $setupDataSql = $packageRoot . '/setup.data.sql';
 
     $assetRoot = helper_find_asset_root($packageRoot);
     if ($assetRoot === null) {
+        if (is_file($setupSql)) {
+            helper_process_sql_file($setupSql);
+        }
+        if (is_file($setupDataSql)) {
+            helper_log('Legacy sample-data SQL detected and skipped by default: ' . basename($setupDataSql));
+        }
         helper_log('Legacy package copied; no install/assets payload detected for inline import.');
         return;
     }
 
-    $items = [];
-    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/chunks', 'chunk'));
-    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/snippets', 'snippet'));
-    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/plugins', 'plugin'));
-    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/modules', 'module'));
+    $payload = helper_collect_install_assets($assetRoot);
+    $items = $payload['items'] ?? [];
+    $dependencies = $payload['dependencies'] ?? [];
+    $profile = helper_detect_legacy_install_profile($items, $dependencies, $packageRoot);
+    helper_log('Legacy package install profile: ' . $profile);
     helper_import_items($items);
+    helper_install_module_dependencies($dependencies);
 
-    $sqlCandidates = [
-        dirname($assetRoot) . '/setup.sql',
-        dirname($assetRoot) . '/setup.data.sql',
-    ];
-    foreach ($sqlCandidates as $candidate) {
-        if (is_file($candidate)) {
-            helper_log('SQL payload detected and skipped for now: ' . basename($candidate));
-        }
+    if (is_file($setupSql)) {
+        helper_process_sql_file($setupSql);
+    }
+
+    if (is_file($setupDataSql)) {
+        helper_log('Legacy sample-data SQL detected and skipped by default: ' . basename($setupDataSql));
     }
 
     helper_log('Installed legacy package: ' . trim((string) ($item['name'] ?? 'package')));

--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -1,0 +1,532 @@
+<?php
+
+declare(strict_types=1);
+
+function helper_fail(string $message, int $code = 1): void
+{
+    fwrite(STDERR, $message . PHP_EOL);
+    exit($code);
+}
+
+function helper_log(string $message): void
+{
+    echo trim($message) . PHP_EOL;
+}
+
+function helper_read_json(string $path): array
+{
+    if (!is_file($path)) {
+        helper_fail("Payload file not found: {$path}");
+    }
+    $raw = file_get_contents($path);
+    if ($raw === false) {
+        helper_fail("Unable to read payload: {$path}");
+    }
+    $data = json_decode($raw, true);
+    if (!is_array($data)) {
+        helper_fail("Payload is not valid JSON.");
+    }
+    return $data;
+}
+
+function helper_bootstrap(string $projectPath): void
+{
+    defined('EVO_API_MODE') || define('EVO_API_MODE', true);
+    defined('IN_INSTALL_MODE') || define('IN_INSTALL_MODE', true);
+    defined('EVO_CLI') || define('EVO_CLI', true);
+    defined('EVO_BASE_PATH') || define('EVO_BASE_PATH', rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+    defined('EVO_CORE_PATH') || define('EVO_CORE_PATH', EVO_BASE_PATH . 'core' . DIRECTORY_SEPARATOR);
+    defined('EVO_SITE_URL') || define('EVO_SITE_URL', '/');
+
+    chdir($projectPath);
+    $bootstrap = is_file($projectPath . '/core/bootstrap.php')
+        ? $projectPath . '/core/bootstrap.php'
+        : $projectPath . '/bootstrap.php';
+    if (!is_file($bootstrap)) {
+        helper_fail("Project bootstrap not found.");
+    }
+    require_once $bootstrap;
+
+    $installFunctions = $projectPath . '/install/src/functions.php';
+    if (!is_file($installFunctions)) {
+        helper_fail("install/src/functions.php is not available. Run extras before finalize removes install/.");
+    }
+    require_once $installFunctions;
+}
+
+function helper_remove_installer_docblock(string $code): string
+{
+    return preg_replace("/^.*?\/\*\*.*?\*\/\s+/s", '', $code, 1) ?? $code;
+}
+
+function helper_plugin_code(string $path): string
+{
+    $parts = preg_split("/(\/\/)?\s*\<\?php/", (string) file_get_contents($path), 2);
+    $code = end($parts);
+    return helper_remove_installer_docblock((string) $code);
+}
+
+function helper_module_code(string $path): string
+{
+    $parts = preg_split("/(\/\/)?\s*\<\?php/", (string) file_get_contents($path), 2);
+    $code = end($parts);
+    return helper_remove_installer_docblock((string) $code);
+}
+
+function helper_snippet_code(string $path): string
+{
+    return helper_remove_installer_docblock((string) file_get_contents($path));
+}
+
+function helper_chunk_code(string $path): string
+{
+    return helper_remove_installer_docblock((string) file_get_contents($path));
+}
+
+function helper_install_plugin(array $item, string $path): void
+{
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $properties = trim((string) ($item['properties'] ?? ''));
+    $guid = trim((string) ($item['guid'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $legacyNames = array_filter(array_map('trim', explode(',', (string) ($item['legacyNames'] ?? ''))));
+    $events = array_filter(array_map('trim', explode(',', (string) ($item['events'] ?? ''))));
+    $disabled = !empty($item['disabled']) ? 1 : 0;
+
+    if (count($legacyNames) > 0) {
+        \EvolutionCMS\Models\SitePlugin::query()->whereIn('name', $legacyNames)->update(['disabled' => 1]);
+    }
+
+    $plugin = helper_plugin_code($path);
+    $pluginDbRecord = \EvolutionCMS\Models\SitePlugin::where('name', $name)->orderBy('id');
+    $prevId = null;
+
+    if ($pluginDbRecord->count() > 0) {
+        $insert = true;
+        foreach ($pluginDbRecord->get()->toArray() as $row) {
+            $props = propUpdate($properties, $row['properties']);
+            if ($row['description'] == $desc) {
+                \EvolutionCMS\Models\SitePlugin::query()->where('id', $row['id'])->update([
+                    'plugincode' => $plugin,
+                    'description' => $desc,
+                    'properties' => $props,
+                ]);
+                $insert = false;
+            } else {
+                \EvolutionCMS\Models\SitePlugin::query()->where('id', $row['id'])->update(['disabled' => 1]);
+            }
+            $prevId = $row['id'];
+        }
+        if ($insert === true) {
+            $props = propUpdate($properties, $row['properties'] ?? '');
+            \EvolutionCMS\Models\SitePlugin::query()->create([
+                'name' => $name,
+                'plugincode' => $plugin,
+                'description' => $desc,
+                'properties' => $props,
+                'moduleguid' => $guid,
+                'disabled' => 0,
+                'category' => $category,
+            ]);
+        }
+    } else {
+        \EvolutionCMS\Models\SitePlugin::query()->create([
+            'name' => $name,
+            'plugincode' => $plugin,
+            'description' => $desc,
+            'properties' => parseProperties($properties, true),
+            'moduleguid' => $guid,
+            'disabled' => $disabled,
+            'category' => $category,
+        ]);
+    }
+
+    if (count($events) > 0) {
+        $sitePlugin = \EvolutionCMS\Models\SitePlugin::where('name', $name)->where('description', $desc)->first();
+        if ($sitePlugin !== null) {
+            $id = $sitePlugin->id;
+            foreach ($events as $event) {
+                $eventName = \EvolutionCMS\Models\SystemEventname::where('name', $event)->first();
+                if ($eventName === null) {
+                    continue;
+                }
+                $prevPriority = null;
+                if ($prevId) {
+                    $pluginEvent = \EvolutionCMS\Models\SitePluginEvent::query()
+                        ->where('pluginid', $prevId)
+                        ->where('evtid', $eventName->getKey())
+                        ->first();
+                    if ($pluginEvent !== null) {
+                        $prevPriority = $pluginEvent->priority;
+                    }
+                }
+                if ($prevPriority === null) {
+                    $pluginEvent = \EvolutionCMS\Models\SitePluginEvent::query()
+                        ->where('evtid', $eventName->getKey())
+                        ->orderBy('priority', 'DESC')
+                        ->first();
+                    if ($pluginEvent !== null) {
+                        $prevPriority = $pluginEvent->priority + 1;
+                    }
+                }
+                if ($prevPriority === null) {
+                    $prevPriority = 0;
+                }
+                \EvolutionCMS\Models\SitePluginEvent::query()->firstOrCreate([
+                    'pluginid' => $id,
+                    'evtid' => $eventName->getKey(),
+                    'priority' => $prevPriority,
+                ]);
+            }
+
+            \EvolutionCMS\Models\SitePluginEvent::query()
+                ->join('system_eventnames', function ($join) use ($events) {
+                    $join->on('site_plugin_events.evtid', '=', 'system_eventnames.id')
+                        ->whereIn('name', $events);
+                })
+                ->whereNull('name')
+                ->where('pluginid', $id)
+                ->delete();
+        }
+    }
+
+    helper_log("Installed plugin: {$name}");
+}
+
+function helper_install_module(array $item, string $path): void
+{
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $properties = trim((string) ($item['properties'] ?? ''));
+    $guid = trim((string) ($item['guid'] ?? ''));
+    $shared = (int) ($item['shareParams'] ?? 0);
+    $icon = trim((string) ($item['icon'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $module = helper_module_code($path);
+    $moduleDb = \EvolutionCMS\Models\SiteModule::query()->where('name', $name)->first();
+    if ($moduleDb !== null) {
+        $props = propUpdate($properties, $moduleDb->properties);
+        \EvolutionCMS\Models\SiteModule::query()->where('name', $name)->update([
+            'modulecode' => $module,
+            'description' => $desc,
+            'properties' => $props,
+            'enable_sharedparams' => $shared,
+            'icon' => $icon,
+        ]);
+    } else {
+        \EvolutionCMS\Models\SiteModule::query()->create([
+            'name' => $name,
+            'guid' => $guid,
+            'category' => $category,
+            'modulecode' => $module,
+            'description' => $desc,
+            'properties' => parseProperties($properties, true),
+            'enable_sharedparams' => $shared,
+            'icon' => $icon,
+        ]);
+    }
+
+    helper_log("Installed module: {$name}");
+}
+
+function helper_install_snippet(array $item, string $path): void
+{
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $properties = trim((string) ($item['properties'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $code = helper_snippet_code($path);
+    $snippet = \EvolutionCMS\Models\SiteSnippet::query()->where('name', $name)->first();
+    if ($snippet !== null) {
+        $props = propUpdate($properties, $snippet->properties);
+        \EvolutionCMS\Models\SiteSnippet::query()->where('name', $name)->update([
+            'snippet' => $code,
+            'description' => $desc,
+            'properties' => $props,
+            'category' => $category,
+        ]);
+    } else {
+        \EvolutionCMS\Models\SiteSnippet::query()->create([
+            'name' => $name,
+            'snippet' => $code,
+            'description' => $desc,
+            'properties' => parseProperties($properties, true),
+            'category' => $category,
+        ]);
+    }
+
+    helper_log("Installed snippet: {$name}");
+}
+
+function helper_install_chunk(array $item, string $path): void
+{
+    $name = trim((string) ($item['name'] ?? ''));
+    if ($name === '') {
+        return;
+    }
+    $desc = trim((string) ($item['description'] ?? ''));
+    $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
+    $code = helper_chunk_code($path);
+    $chunk = \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $name)->first();
+    if ($chunk !== null) {
+        \EvolutionCMS\Models\SiteHtmlsnippet::query()->where('name', $name)->update([
+            'snippet' => $code,
+            'description' => $desc,
+            'category' => $category,
+        ]);
+    } else {
+        \EvolutionCMS\Models\SiteHtmlsnippet::query()->create([
+            'name' => $name,
+            'snippet' => $code,
+            'description' => $desc,
+            'category' => $category,
+        ]);
+    }
+
+    helper_log("Installed chunk: {$name}");
+}
+
+function helper_scan_tpl_dir(string $dir, string $kind): array
+{
+    $items = [];
+    if (!is_dir($dir)) {
+        return $items;
+    }
+    $files = scandir($dir) ?: [];
+    foreach ($files as $file) {
+        if (!str_ends_with($file, '.tpl')) {
+            continue;
+        }
+        $params = parse_docblock($dir, $file);
+        if (!is_array($params) || count($params) === 0) {
+            continue;
+        }
+        $description = trim((string) ($params['description'] ?? ''));
+        $version = trim((string) ($params['version'] ?? ''));
+        if ($version !== '') {
+            $description = "<strong>{$version}</strong> {$description}";
+        }
+        $items[] = [
+            'kind' => $kind,
+            'name' => trim((string) ($params['name'] ?? '')),
+            'description' => $description,
+            'path' => $dir . DIRECTORY_SEPARATOR . $file,
+            'properties' => trim((string) ($params['properties'] ?? '')),
+            'events' => trim((string) ($params['events'] ?? '')),
+            'guid' => trim((string) ($params['guid'] ?? '')),
+            'category' => trim((string) ($params['modx_category'] ?? '')),
+            'legacyNames' => trim((string) ($params['legacy_names'] ?? '')),
+            'disabled' => trim((string) ($params['disabled'] ?? '')) === '1',
+            'shareParams' => (int) trim((string) ($params['shareparams'] ?? '0')),
+            'icon' => trim((string) ($params['icon'] ?? '')),
+        ];
+    }
+    return $items;
+}
+
+function helper_import_items(array $items): void
+{
+    foreach ($items as $item) {
+        $path = (string) ($item['path'] ?? '');
+        if ($path === '' || !is_file($path)) {
+            continue;
+        }
+        switch ((string) ($item['kind'] ?? '')) {
+            case 'plugin':
+                helper_install_plugin($item, $path);
+                break;
+            case 'module':
+                helper_install_module($item, $path);
+                break;
+            case 'snippet':
+                helper_install_snippet($item, $path);
+                break;
+            case 'chunk':
+                helper_install_chunk($item, $path);
+                break;
+        }
+    }
+}
+
+function helper_recursive_copy(string $src, string $dest): void
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iterator as $item) {
+        $target = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
+        if ($item->isDir()) {
+            if (!is_dir($target)) {
+                mkdir($target, 0775, true);
+            }
+            continue;
+        }
+        if (!is_dir(dirname($target))) {
+            mkdir(dirname($target), 0775, true);
+        }
+        copy($item->getPathname(), $target);
+    }
+}
+
+function helper_download_file(string $url, string $target): void
+{
+    $context = stream_context_create([
+        'http' => [
+            'timeout' => 60,
+            'follow_location' => 1,
+            'user_agent' => 'EvolutionCMS-Installer',
+        ],
+    ]);
+    $raw = @file_get_contents($url, false, $context);
+    if ($raw === false || $raw === '') {
+        helper_fail("Unable to download legacy package: {$url}");
+    }
+    if (file_put_contents($target, $raw) === false) {
+        helper_fail("Unable to write downloaded package.");
+    }
+}
+
+function helper_find_package_root(string $extractDir): string
+{
+    $entries = array_values(array_filter(scandir($extractDir) ?: [], function ($name) use ($extractDir) {
+        return $name !== '.' && $name !== '..' && is_dir($extractDir . DIRECTORY_SEPARATOR . $name);
+    }));
+    if (count($entries) === 1) {
+        return $extractDir . DIRECTORY_SEPARATOR . $entries[0];
+    }
+    return $extractDir;
+}
+
+function helper_find_asset_root(string $baseDir): ?string
+{
+    $candidates = [
+        $baseDir . '/install/assets',
+        $baseDir . '/assets',
+    ];
+    foreach ($candidates as $candidate) {
+        if (is_dir($candidate)) {
+            return $candidate;
+        }
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($baseDir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iterator as $item) {
+        if (!$item->isDir()) {
+            continue;
+        }
+        $path = $item->getPathname();
+        if (is_dir($path . '/plugins') || is_dir($path . '/modules') || is_dir($path . '/snippets') || is_dir($path . '/chunks')) {
+            if (basename($path) === 'assets') {
+                return $path;
+            }
+        }
+    }
+    return null;
+}
+
+function helper_install_legacy_store_package(string $projectPath, array $item): void
+{
+    $url = trim((string) ($item['downloadUrl'] ?? ''));
+    if ($url === '') {
+        helper_fail('Legacy store package is missing a download URL.');
+    }
+
+    $tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'evo-installer-legacy-' . bin2hex(random_bytes(6));
+    mkdir($tempDir, 0775, true);
+    $zipPath = $tempDir . '/package.zip';
+    $extractDir = $tempDir . '/extract';
+    mkdir($extractDir, 0775, true);
+
+    helper_download_file($url, $zipPath);
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath) !== true) {
+        helper_fail("Unable to open legacy package archive.");
+    }
+    $zip->extractTo($extractDir);
+    $zip->close();
+
+    $packageRoot = helper_find_package_root($extractDir);
+    helper_recursive_copy($packageRoot, $projectPath);
+
+    $assetRoot = helper_find_asset_root($packageRoot);
+    if ($assetRoot === null) {
+        helper_log('Legacy package copied; no install/assets payload detected for inline import.');
+        return;
+    }
+
+    $items = [];
+    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/chunks', 'chunk'));
+    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/snippets', 'snippet'));
+    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/plugins', 'plugin'));
+    $items = array_merge($items, helper_scan_tpl_dir($assetRoot . '/modules', 'module'));
+    helper_import_items($items);
+
+    $sqlCandidates = [
+        dirname($assetRoot) . '/setup.sql',
+        dirname($assetRoot) . '/setup.data.sql',
+    ];
+    foreach ($sqlCandidates as $candidate) {
+        if (is_file($candidate)) {
+            helper_log('SQL payload detected and skipped for now: ' . basename($candidate));
+        }
+    }
+
+    helper_log('Installed legacy package: ' . trim((string) ($item['name'] ?? 'package')));
+}
+
+$projectPath = $argv[1] ?? '';
+$mode = $argv[2] ?? '';
+$payloadPath = $argv[3] ?? '';
+
+if ($projectPath === '' || $mode === '' || $payloadPath === '') {
+    helper_fail('Usage: php extras_helper.php <project-path> <mode> <payload.json>');
+}
+
+$projectPath = rtrim((string) realpath($projectPath), DIRECTORY_SEPARATOR);
+if ($projectPath === '') {
+    helper_fail('Project path is invalid.');
+}
+
+helper_bootstrap($projectPath);
+$payload = helper_read_json($payloadPath);
+
+switch ($mode) {
+    case 'bundled-inline':
+        $items = $payload['items'] ?? [];
+        if (!is_array($items) || count($items) === 0) {
+            helper_fail('No bundled inline items were provided.');
+        }
+        foreach ($items as &$item) {
+            if (!isset($item['path'])) {
+                continue;
+            }
+            $item['path'] = $projectPath . DIRECTORY_SEPARATOR . ltrim((string) $item['path'], DIRECTORY_SEPARATOR);
+        }
+        unset($item);
+        helper_import_items($items);
+        break;
+
+    case 'legacy-store':
+        $item = $payload['item'] ?? null;
+        if (!is_array($item)) {
+            helper_fail('No legacy package payload was provided.');
+        }
+        helper_install_legacy_store_package($projectPath, $item);
+        break;
+
+    default:
+        helper_fail('Unsupported helper mode: ' . $mode);
+}

--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -49,7 +49,10 @@ function helper_bootstrap(string $projectPath): void
 
     $installFunctions = $projectPath . '/install/src/functions.php';
     if (!is_file($installFunctions)) {
-        helper_fail("install/src/functions.php is not available. Run extras before finalize removes install/.");
+        $installFunctions = $projectPath . '/core/.evo-installer-runtime/install/src/functions.php';
+    }
+    if (!is_file($installFunctions)) {
+        helper_fail("install/src/functions.php is not available.");
     }
     require_once $installFunctions;
 }

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -1,6 +1,11 @@
 package install
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/evolution-cms/installer/internal/domain"
+)
 
 func TestParseExtrasListJSONWrapped(t *testing.T) {
 	t.Parallel()
@@ -49,5 +54,105 @@ func TestParseExtrasListJSONError(t *testing.T) {
 	raw := []byte(`{"ok":false,"error":"rate limit"}`)
 	if _, err := parseExtrasListJSON(raw); err == nil {
 		t.Fatalf("expected error for ok=false payload")
+	}
+}
+
+func TestParseLegacyStoreCatalogJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"category":[{"id":"2","title":"Catalog"}],
+		"allcategory":{
+			"2":[
+				{
+					"id":"84",
+					"url":{"fieldValue":[
+						{"file":"https://github.com/extras-evolution/ajaxSearch/archive/1.12.2.zip","version":"1.12.2","date":"25-01-2021"},
+						{"file":"https://github.com/extras-evolution/ajaxSearch/archive/master.zip","version":"master","date":"04-11-2017"}
+					]},
+					"method":"package",
+					"type":"snippet",
+					"downloads":"25791",
+					"dependencies":"",
+					"description":"Ajax and non-Ajax search",
+					"title":"AjaxSearch",
+					"author":"Coroico",
+					"name_in_modx":"AjaxSearch",
+					"deprecated":"0"
+				}
+			]
+		}
+	}`)
+
+	pkgs, err := parseLegacyStoreCatalogJSON(raw)
+	if err != nil {
+		t.Fatalf("parseLegacyStoreCatalogJSON error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(pkgs))
+	}
+	pkg := pkgs[0]
+	if pkg.ID != "legacy-store:84" {
+		t.Fatalf("unexpected id: %q", pkg.ID)
+	}
+	if pkg.Source != "legacy-store" {
+		t.Fatalf("unexpected source: %q", pkg.Source)
+	}
+	if pkg.DownloadURL == "" {
+		t.Fatalf("expected download url to be populated")
+	}
+	if len(pkg.Versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(pkg.Versions))
+	}
+}
+
+func TestNormalizeExtrasSelectionsUsesIDsAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "bundled-inline:codemirror",
+			Name:               "CodeMirror",
+			Source:             "bundled-inline",
+			DefaultInstallMode: "bundled-inline",
+			Preselected:        true,
+		},
+		{
+			ID:                 "managed:sSeo",
+			Name:               "sSeo",
+			Source:             "managed",
+			Version:            "1.2.3",
+			DefaultInstallMode: "latest-release",
+		},
+	}
+
+	selections := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{ID: "bundled-inline:codemirror"},
+		{Name: "sSeo"},
+	})
+	if len(selections) != 2 {
+		t.Fatalf("expected 2 selections, got %d", len(selections))
+	}
+	if selections[0].Source != "bundled-inline" {
+		t.Fatalf("unexpected source for bundled selection: %q", selections[0].Source)
+	}
+	if selections[1].Version != "1.2.3" {
+		t.Fatalf("expected managed default version, got %q", selections[1].Version)
+	}
+}
+
+func TestParseExtrasDocblockFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "bundled_plugin.tpl")
+	doc, err := parseExtrasDocblockFile(path)
+	if err != nil {
+		t.Fatalf("parseExtrasDocblockFile error: %v", err)
+	}
+	if doc.Name != "CodeMirror" {
+		t.Fatalf("unexpected name: %q", doc.Name)
+	}
+	if doc.Tags["events"] == "" {
+		t.Fatalf("expected events tag to be parsed")
 	}
 }

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -201,3 +201,26 @@ func TestLoadBundledInlineExtrasUsesRuntimeCacheFallback(t *testing.T) {
 		t.Fatalf("unexpected fallback path: %q", pkgs[0].Path)
 	}
 }
+
+func TestDetectExtrasFailureRecognizesSqliteStackTrace(t *testing.T) {
+	t.Parallel()
+
+	out := `
+   INFO  Running migrations.
+
+  2026_03_29_000000_create_file_groups_table ..................... 1.07ms FAIL
+SQLSTATE[HY000]: General error: 1 table "evo_file_groups" already exists
+File: /tmp/core/vendor/illuminate/database/Connection.php
+Line: 838
+Stack trace:
+#1. Symfony\Component\Console\Application->run(...)
+`
+
+	got := detectExtrasFailure(out)
+	if got == "" {
+		t.Fatalf("expected detectExtrasFailure to recognize SQLSTATE stack trace")
+	}
+	if got != `SQLSTATE[HY000]: General error: 1 table "evo_file_groups" already exists` {
+		t.Fatalf("unexpected detected failure: %q", got)
+	}
+}

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -154,5 +155,49 @@ func TestParseExtrasDocblockFile(t *testing.T) {
 	}
 	if doc.Tags["events"] == "" {
 		t.Fatalf("expected events tag to be parsed")
+	}
+}
+
+func TestLoadBundledInlineExtrasUsesRuntimeCacheFallback(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	pluginDir := filepath.Join(workDir, extrasRuntimeCacheDir, "install", "assets", "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+
+	path := filepath.Join(pluginDir, "CodeMirror.tpl")
+	raw := `//<?php
+/**
+ * CodeMirror
+ *
+ * Bundled plugin description
+ *
+ * @internal    @events OnDocFormRender
+ * @internal    @modx_category Manager and Admin
+ * @internal    @installset base
+ * @version     1.6
+ */
+`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write plugin tpl: %v", err)
+	}
+
+	pkgs, err := loadBundledInlineExtras(workDir)
+	if err != nil {
+		t.Fatalf("loadBundledInlineExtras error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 bundled package, got %d", len(pkgs))
+	}
+	if pkgs[0].Source != "bundled-inline" {
+		t.Fatalf("unexpected source: %q", pkgs[0].Source)
+	}
+	if !pkgs[0].Preselected {
+		t.Fatalf("expected bundled package to be preselected from installset base")
+	}
+	if pkgs[0].Path != "core/.evo-installer-runtime/install/assets/plugins/CodeMirror.tpl" {
+		t.Fatalf("unexpected fallback path: %q", pkgs[0].Path)
 	}
 }

--- a/internal/engine/install/testdata/bundled_plugin.tpl
+++ b/internal/engine/install/testdata/bundled_plugin.tpl
@@ -1,0 +1,13 @@
+//<?php
+/**
+ * CodeMirror
+ *
+ * JavaScript editor
+ *
+ * @internal    @events OnDocFormRender,OnChunkFormRender
+ * @internal    @modx_category Manager and Admin
+ * @internal    @properties &theme=Theme;list;default;default
+ * @internal    @installset base
+ */
+
+require(EVO_BASE_PATH . 'assets/plugins/codemirror/codemirror.plugin.php');

--- a/internal/engine/mock/engine.go
+++ b/internal/engine/mock/engine.go
@@ -269,9 +269,9 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, _ <-chan domai
 					ID:     "db_driver",
 					Prompt: "Which database driver do you want to use?",
 					Options: []domain.QuestionOption{
+						{ID: "sqlite", Label: "SQLite", Enabled: true},
 						{ID: "mysql", Label: "MySQL or MariaDB", Enabled: true},
 						{ID: "pgsql", Label: "PostgreSQL", Enabled: true},
-						{ID: "sqlite", Label: "SQLite", Enabled: true},
 						{ID: "sqlsrv", Label: "SQL Server", Enabled: true, Reason: "Driver may be missing"},
 					},
 					Selected: 0,

--- a/internal/logging/eventlog.go
+++ b/internal/logging/eventlog.go
@@ -96,6 +96,7 @@ func (l *EventLogger) Record(ev domain.Event) {
 			ok = p.OK
 		}
 		if !ok && ev.StepID != "" {
+			l.hadError = true
 			l.failedSteps[ev.StepID] = true
 		}
 		label := l.stepLabels[ev.StepID]

--- a/internal/logging/eventlog_test.go
+++ b/internal/logging/eventlog_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/evolution-cms/installer/internal/domain"
+)
+
+func TestFinalizeWritesLogWhenStepDoneFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logger := NewEventLogger(Config{InstallDir: dir})
+	logger.Record(domain.Event{
+		Type:   domain.EventStepDone,
+		StepID: "extras",
+		Payload: domain.StepDonePayload{
+			OK: false,
+		},
+	})
+
+	res, err := logger.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize error: %v", err)
+	}
+	if !res.Written {
+		t.Fatalf("expected log to be written for failed step")
+	}
+}

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -240,6 +240,10 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 			return
 		}
 		m.extras.cursor++
+	case "right":
+		m.extras.focus = extrasFocusActions
+		m.extras.action = 0
+		return
 	case "pgup", "pageup":
 		m.extras.cursor -= listHeight
 	case "pgdown", "pagedown":

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -674,12 +674,12 @@ func (m *Model) renderExtrasSummary(width int, height int) string {
 		resH := max(1, contentMain/2)
 		detH := max(1, contentMain-resH)
 		lines = append(lines, m.renderExtrasSummaryResults(contentW, resH)...)
+		lines = append(lines, "", truncatePlain("Details:", contentW))
+		lines = append(lines, m.renderExtrasSummaryDetail(contentW, detH)...)
 		if len(introLines) > 0 {
 			lines = append(lines, "")
 			lines = append(lines, introLines...)
 		}
-		lines = append(lines, "", truncatePlain("Details:", contentW))
-		lines = append(lines, m.renderExtrasSummaryDetail(contentW, detH)...)
 	} else {
 		introH := len(introLines)
 		if introH > 0 {

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -704,18 +705,50 @@ func (m *Model) renderExtrasSummaryIntro(width int) []string {
 	}
 
 	if strings.TrimSpace(m.extras.projectPath) != "" {
-		lines = append(lines,
-			"",
-			truncatePlain("If this is a local install on your computer, run:", width),
-			truncatePlain("cd "+strconv.Quote(m.extras.projectPath), width),
-			truncatePlain("php -S localhost:8000", width),
-			truncatePlain("Then open http://localhost:8000", width),
-			"",
-			truncatePlain("If this was installed on a server, open the site by its configured URL/domain.", width),
-		)
+		lines = append(lines, "")
+		lines = append(lines, m.renderExtrasSummaryLocalRunHint(width)...)
 	}
 
 	lines = append(lines, "")
+	return lines
+}
+
+func (m *Model) renderExtrasSummaryLocalRunHint(width int) []string {
+	path := strings.TrimSpace(m.extras.projectPath)
+	if path == "" {
+		return nil
+	}
+
+	quoted := strconv.Quote(path)
+	lines := []string{}
+
+	switch runtime.GOOS {
+	case "windows":
+		lines = append(lines,
+			truncatePlain("If this is a local install on Windows, run:", width),
+			truncatePlain("PowerShell: cd "+quoted, width),
+			truncatePlain("cmd.exe: cd /d "+quoted, width),
+			truncatePlain("php -S localhost:8000", width),
+			truncatePlain("Then open http://localhost:8000", width),
+		)
+	default:
+		lines = append(lines,
+			truncatePlain("If this is a local install on macOS/Linux, run:", width),
+			truncatePlain("cd "+quoted, width),
+			truncatePlain("php -S localhost:8000", width),
+			truncatePlain("Then open http://localhost:8000", width),
+			"",
+			truncatePlain("On Windows use PowerShell: cd "+quoted, width),
+			truncatePlain("Or cmd.exe: cd /d "+quoted, width),
+			truncatePlain("Then run: php -S localhost:8000", width),
+		)
+	}
+
+	lines = append(lines,
+		"",
+		truncatePlain("If this was installed on a server, open the site by its configured URL/domain.", width),
+	)
+
 	return lines
 }
 

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -649,12 +649,12 @@ func (m *Model) renderExtrasSummary(width int, height int) string {
 		return minSizeView(width, height)
 	}
 	contentW := panelContentWidth(width)
+	introLines := m.renderExtrasSummaryIntro(contentW)
 
 	lines := []string{
 		truncatePlain("Extras installation summary.", contentW),
 		"",
 	}
-	lines = append(lines, m.renderExtrasSummaryIntro(contentW)...)
 
 	contentHeight := innerH - len(lines) - 2
 	if contentHeight < 1 {
@@ -662,18 +662,38 @@ func (m *Model) renderExtrasSummary(width int, height int) string {
 	}
 
 	if len(m.extras.details) > 0 {
+		introH := len(introLines)
+		if introH > 0 {
+			introH++
+		}
 		detailsLabelH := 1
-		contentMain := contentHeight - detailsLabelH
+		contentMain := contentHeight - introH - detailsLabelH
 		if contentMain < 1 {
 			contentMain = 1
 		}
 		resH := max(1, contentMain/2)
 		detH := max(1, contentMain-resH)
 		lines = append(lines, m.renderExtrasSummaryResults(contentW, resH)...)
+		if len(introLines) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, introLines...)
+		}
 		lines = append(lines, "", truncatePlain("Details:", contentW))
 		lines = append(lines, m.renderExtrasSummaryDetail(contentW, detH)...)
 	} else {
-		lines = append(lines, m.renderExtrasSummaryResults(contentW, contentHeight)...)
+		introH := len(introLines)
+		if introH > 0 {
+			introH++
+		}
+		resH := contentHeight - introH
+		if resH < 1 {
+			resH = 1
+		}
+		lines = append(lines, m.renderExtrasSummaryResults(contentW, resH)...)
+		if len(introLines) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, introLines...)
+		}
 	}
 
 	lines = append(lines, "", m.renderExtrasSummaryActions(contentW))
@@ -705,11 +725,8 @@ func (m *Model) renderExtrasSummaryIntro(width int) []string {
 	}
 
 	if strings.TrimSpace(m.extras.projectPath) != "" {
-		lines = append(lines, "")
 		lines = append(lines, m.renderExtrasSummaryLocalRunHint(width)...)
 	}
-
-	lines = append(lines, "")
 	return lines
 }
 
@@ -737,10 +754,6 @@ func (m *Model) renderExtrasSummaryLocalRunHint(width int) []string {
 			truncatePlain("cd "+quoted, width),
 			truncatePlain("php -S localhost:8000", width),
 			truncatePlain("Then open http://localhost:8000", width),
-			"",
-			truncatePlain("On Windows use PowerShell: cd "+quoted, width),
-			truncatePlain("Or cmd.exe: cd /d "+quoted, width),
-			truncatePlain("Then run: php -S localhost:8000", width),
 		)
 	}
 

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -43,6 +44,7 @@ type extrasUIState struct {
 	current       string
 	currentIndex  int
 	total         int
+	projectPath   string
 	details       []domain.ExtrasItemDetail
 	showDetails   bool
 	summaryCursor int
@@ -62,6 +64,7 @@ func (m *Model) applyExtrasState(state domain.ExtrasState) {
 	m.extras.current = state.Current
 	m.extras.currentIndex = state.CurrentIndex
 	m.extras.total = state.Total
+	m.extras.projectPath = state.ProjectPath
 	m.extras.details = state.Details
 	if state.Stage != domain.ExtrasStageSelect {
 		m.extras.versionPickerActive = false
@@ -650,6 +653,7 @@ func (m *Model) renderExtrasSummary(width int, height int) string {
 		truncatePlain("Extras installation summary.", contentW),
 		"",
 	}
+	lines = append(lines, m.renderExtrasSummaryIntro(contentW)...)
 
 	contentHeight := innerH - len(lines) - 2
 	if contentHeight < 1 {
@@ -674,6 +678,57 @@ func (m *Model) renderExtrasSummary(width int, height int) string {
 	lines = append(lines, "", m.renderExtrasSummaryActions(contentW))
 	body := strings.Join(lines, "\n")
 	return panel("Extras summary", body, width, height)
+}
+
+func (m *Model) renderExtrasSummaryIntro(width int) []string {
+	if width <= 0 {
+		return nil
+	}
+
+	if len(m.extras.results) == 1 && m.extras.results[0].Name == "Extras skipped" {
+		return []string{
+			truncatePlain("Extras were skipped for this installation.", width),
+			"",
+		}
+	}
+
+	if !m.extrasSummaryAllSuccess() {
+		return []string{
+			truncatePlain("Some extras finished with warnings or errors. Review the results below before testing.", width),
+			"",
+		}
+	}
+
+	lines := []string{
+		okStyle.Copy().Bold(true).Render(truncatePlain("All selected extras were installed successfully.", width)),
+	}
+
+	if strings.TrimSpace(m.extras.projectPath) != "" {
+		lines = append(lines,
+			"",
+			truncatePlain("If this is a local install on your computer, run:", width),
+			truncatePlain("cd "+strconv.Quote(m.extras.projectPath), width),
+			truncatePlain("php -S localhost:8000", width),
+			truncatePlain("Then open http://localhost:8000", width),
+			"",
+			truncatePlain("If this was installed on a server, open the site by its configured URL/domain.", width),
+		)
+	}
+
+	lines = append(lines, "")
+	return lines
+}
+
+func (m *Model) extrasSummaryAllSuccess() bool {
+	if len(m.extras.results) == 0 {
+		return false
+	}
+	for _, result := range m.extras.results {
+		if result.Status != domain.ExtrasStatusSuccess {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *Model) renderExtrasSummaryResults(width int, height int) []string {

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -73,13 +73,13 @@ func (m *Model) applyExtrasState(state domain.ExtrasState) {
 			m.extras.selected = map[string]bool{}
 			m.extras.versions = map[string]string{}
 			for _, sel := range state.Selections {
-				name := strings.TrimSpace(sel.Name)
-				if name == "" {
+				key := extrasSelectionKey(sel)
+				if key == "" {
 					continue
 				}
-				m.extras.selected[name] = true
+				m.extras.selected[key] = true
 				if v := strings.TrimSpace(sel.Version); v != "" {
-					m.extras.versions[name] = v
+					m.extras.versions[key] = v
 				}
 			}
 			m.extras.cursor = 0
@@ -119,7 +119,7 @@ func extrasPackagesEqual(a []domain.ExtrasPackage, b []domain.ExtrasPackage) boo
 		return false
 	}
 	for i := range a {
-		if a[i].Name != b[i].Name || a[i].Version != b[i].Version {
+		if a[i].ID != b[i].ID || a[i].Name != b[i].Name || a[i].Version != b[i].Version || a[i].Source != b[i].Source || a[i].Section != b[i].Section || a[i].Preselected != b[i].Preselected {
 			return false
 		}
 		if len(a[i].Versions) != len(b[i].Versions) {
@@ -255,20 +255,20 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 		if listLen == 0 || m.extras.cursor < 0 || m.extras.cursor >= listLen {
 			return
 		}
-		name := m.extras.packages[m.extras.cursor].Name
-		if name == "" {
+		key := extrasPackageKey(m.extras.packages[m.extras.cursor])
+		if key == "" {
 			return
 		}
 		if m.extras.selected == nil {
 			m.extras.selected = map[string]bool{}
 		}
-		if m.extras.selected[name] {
-			delete(m.extras.selected, name)
+		if m.extras.selected[key] {
+			delete(m.extras.selected, key)
 			if m.extras.versions != nil {
-				delete(m.extras.versions, name)
+				delete(m.extras.versions, key)
 			}
 		} else {
-			m.extras.selected[name] = true
+			m.extras.selected[key] = true
 		}
 	}
 
@@ -320,15 +320,16 @@ func (m *Model) extrasSelectedNames() []domain.ExtrasSelection {
 	}
 	out := make([]domain.ExtrasSelection, 0, len(m.extras.selected))
 	for _, pkg := range m.extras.packages {
-		if pkg.Name == "" {
+		key := extrasPackageKey(pkg)
+		if key == "" {
 			continue
 		}
-		if m.extras.selected[pkg.Name] {
+		if m.extras.selected[key] {
 			version := ""
 			if m.extras.versions != nil {
-				version = strings.TrimSpace(m.extras.versions[pkg.Name])
+				version = strings.TrimSpace(m.extras.versions[key])
 			}
-			out = append(out, domain.ExtrasSelection{Name: pkg.Name, Version: version})
+			out = append(out, domain.ExtrasSelection{ID: key, Name: pkg.Name, Source: pkg.Source, Version: version})
 		}
 	}
 	return out
@@ -340,23 +341,23 @@ func selectionsToValues(selections []domain.ExtrasSelection) []string {
 	}
 	out := make([]string, 0, len(selections))
 	for _, sel := range selections {
-		name := strings.TrimSpace(sel.Name)
-		if name == "" {
+		key := extrasSelectionKey(sel)
+		if key == "" {
 			continue
 		}
 		version := strings.TrimSpace(sel.Version)
 		if version == "" {
-			out = append(out, name)
+			out = append(out, key)
 		} else {
-			out = append(out, name+"@"+version)
+			out = append(out, key+"@"+version)
 		}
 	}
 	return out
 }
 
 func (m *Model) openExtrasVersionPicker(pkg domain.ExtrasPackage) {
-	name := strings.TrimSpace(pkg.Name)
-	if name == "" {
+	key := extrasPackageKey(pkg)
+	if key == "" {
 		return
 	}
 	options, values := buildExtrasVersionOptions(pkg)
@@ -364,14 +365,14 @@ func (m *Model) openExtrasVersionPicker(pkg domain.ExtrasPackage) {
 		return
 	}
 	m.extras.versionPickerActive = true
-	m.extras.versionPickerPkg = name
+	m.extras.versionPickerPkg = key
 	m.extras.versionPickerOptions = options
 	m.extras.versionPickerValues = values
 	m.extras.versionPickerCursor = 0
 
 	current := ""
 	if m.extras.versions != nil {
-		current = strings.TrimSpace(m.extras.versions[name])
+		current = strings.TrimSpace(m.extras.versions[key])
 	}
 	for i, v := range values {
 		if strings.TrimSpace(v) == current {
@@ -574,7 +575,7 @@ func (m *Model) renderExtrasVersionPicker(width int, height int) string {
 
 	contentW := panelContentWidth(boxW)
 	lines := []string{
-		truncatePlain("Select version for "+m.extras.versionPickerPkg, contentW),
+		truncatePlain("Select package version", contentW),
 		"",
 	}
 	lines = append(lines, m.renderExtrasVersionOptions(contentW, listH)...)
@@ -793,9 +794,20 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 	}
 
 	out := make([]string, 0, height)
+	currentSection := ""
 	for i := 0; i < visible; i++ {
 		idx := start + i
 		pkg := m.extras.packages[idx]
+		key := extrasPackageKey(pkg)
+		section := strings.TrimSpace(pkg.Section)
+		if section != "" && section != currentSection && len(out) < height {
+			header := truncatePlain("  "+section, width)
+			out = append(out, mutedStyle.Copy().Bold(true).Render(header))
+			currentSection = section
+			if len(out) >= height {
+				break
+			}
+		}
 
 		cursor := " "
 		style := mutedStyle
@@ -805,13 +817,13 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		}
 
 		checked := "[ ]"
-		if m.extras.selected != nil && m.extras.selected[pkg.Name] {
+		if m.extras.selected != nil && m.extras.selected[key] {
 			checked = "[x]"
 		}
 
 		version := ""
 		if m.extras.versions != nil {
-			version = strings.TrimSpace(m.extras.versions[pkg.Name])
+			version = strings.TrimSpace(m.extras.versions[key])
 		}
 		if version == "" {
 			version = strings.TrimSpace(pkg.Version)
@@ -823,7 +835,7 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 			version = "default"
 		}
 		desc := strings.TrimSpace(pkg.Description)
-		label := fmt.Sprintf("%s %s %s @ %s", cursor, checked, pkg.Name, version)
+		label := fmt.Sprintf("%s %s %s%s @ %s", cursor, checked, extrasSourcePrefix(pkg), pkg.Name, version)
 		if desc != "" {
 			label += " - " + desc
 		}
@@ -836,6 +848,37 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		out = append(out, "")
 	}
 	return out[:height]
+}
+
+func extrasPackageKey(pkg domain.ExtrasPackage) string {
+	if id := strings.TrimSpace(pkg.ID); id != "" {
+		return id
+	}
+	if source := strings.TrimSpace(pkg.Source); source != "" {
+		return source + ":" + strings.TrimSpace(pkg.Name)
+	}
+	return strings.TrimSpace(pkg.Name)
+}
+
+func extrasSelectionKey(sel domain.ExtrasSelection) string {
+	if id := strings.TrimSpace(sel.ID); id != "" {
+		return id
+	}
+	if source := strings.TrimSpace(sel.Source); source != "" {
+		return source + ":" + strings.TrimSpace(sel.Name)
+	}
+	return strings.TrimSpace(sel.Name)
+}
+
+func extrasSourcePrefix(pkg domain.ExtrasPackage) string {
+	switch strings.TrimSpace(pkg.Source) {
+	case "bundled-inline":
+		return "[bundled] "
+	case "legacy-store":
+		return "[legacy] "
+	default:
+		return "[managed] "
+	}
 }
 
 func (m *Model) renderExtrasVersionOptions(width int, height int) []string {

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -1,0 +1,28 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/evolution-cms/installer/internal/domain"
+)
+
+func TestHandleExtrasSelectKeyRightMovesFocusToInstallAction(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.extras.active = true
+	m.extras.stage = domain.ExtrasStageSelect
+	m.extras.focus = extrasFocusList
+	m.extras.packages = []domain.ExtrasPackage{
+		{ID: "bundled-inline:codemirror", Name: "CodeMirror"},
+	}
+
+	m.handleExtrasSelectKey("", "right")
+
+	if m.extras.focus != extrasFocusActions {
+		t.Fatalf("expected focus to move to actions, got %v", m.extras.focus)
+	}
+	if m.extras.action != 0 {
+		t.Fatalf("expected install action to be selected, got %d", m.extras.action)
+	}
+}

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3471,9 +3471,11 @@ class InstallCommand extends Command
 
         // Remove repository-only files from project root
         foreach ([
+            'AGENTS.md',
             '.gitattributes',
             'LICENSE',
             'ng.inx',
+            'publiccode.yml',
             'README.md',
             'phpstan.neon',
         ] as $file) {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3446,6 +3446,7 @@ class InstallCommand extends Command
         $this->removeInstallerAdminEnvVars($projectPath);
         $this->removeCoreCustomExampleFiles($projectPath);
         $this->applyManagerDirectory($projectPath, $options);
+        $this->preserveExtrasRuntimeArtifacts($projectPath);
 
         // Remove install directory
         $installDir = $projectPath . '/install';
@@ -3549,6 +3550,90 @@ class InstallCommand extends Command
         $this->steps['finalize']['completed'] = true;
         $this->tui->setQuestTrack($this->steps);
         $this->tui->addLog('Installation finalized successfully.', 'success');
+    }
+
+    protected function preserveExtrasRuntimeArtifacts(string $projectPath): void
+    {
+        $installDir = rtrim($projectPath, '/\\') . DIRECTORY_SEPARATOR . 'install';
+        if (!is_dir($installDir)) {
+            return;
+        }
+
+        $runtimeRoot = rtrim($projectPath, '/\\') . DIRECTORY_SEPARATOR . 'core/.evo-installer-runtime';
+        $runtimeInstall = $runtimeRoot . DIRECTORY_SEPARATOR . 'install';
+
+        if (is_dir($runtimeRoot)) {
+            $this->removeDirectory($runtimeRoot);
+        }
+        if (!@mkdir($runtimeInstall, 0755, true) && !is_dir($runtimeInstall)) {
+            $this->tui->addLog('Failed to create extras runtime cache directory.', 'warning');
+            return;
+        }
+
+        $preserved = 0;
+        foreach (['assets', 'src'] as $subdir) {
+            $source = $installDir . DIRECTORY_SEPARATOR . $subdir;
+            if (!is_dir($source)) {
+                continue;
+            }
+            try {
+                $this->copyDirectoryQuiet($source, $runtimeInstall . DIRECTORY_SEPARATOR . $subdir);
+                $preserved++;
+            } catch (\Throwable $e) {
+                $this->tui->addLog("Failed to preserve install/{$subdir} for extras runtime: " . $e->getMessage(), 'warning');
+            }
+        }
+
+        if ($preserved > 0) {
+            $this->tui->addLog('Preserved installer extras runtime artifacts.');
+        }
+    }
+
+    protected function copyDirectoryQuiet(string $source, string $destination): void
+    {
+        $source = rtrim($source, "/\\");
+        $destination = rtrim($destination, "/\\");
+
+        if (!is_dir($source)) {
+            throw new \RuntimeException("Source directory not found: {$source}");
+        }
+
+        if (!is_dir($destination) && !@mkdir($destination, 0755, true) && !is_dir($destination)) {
+            throw new \RuntimeException("Failed to create destination directory: {$destination}");
+        }
+
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($it as $item) {
+            $srcPath = $item->getPathname();
+            $rel = substr($srcPath, strlen($source) + 1);
+            if ($rel === false || $rel === '') {
+                continue;
+            }
+            if ($this->shouldSkipCopiedPath($rel)) {
+                continue;
+            }
+
+            $dstPath = $destination . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $rel);
+            if ($item->isDir()) {
+                if (!is_dir($dstPath) && !@mkdir($dstPath, 0755, true) && !is_dir($dstPath)) {
+                    throw new \RuntimeException("Failed to create directory: {$dstPath}");
+                }
+                continue;
+            }
+
+            $dstDir = dirname($dstPath);
+            if (!is_dir($dstDir) && !@mkdir($dstDir, 0755, true) && !is_dir($dstDir)) {
+                throw new \RuntimeException("Failed to create directory: {$dstDir}");
+            }
+
+            if (!@copy($srcPath, $dstPath)) {
+                throw new \RuntimeException("Failed to copy file: {$rel}");
+            }
+            @chmod($dstPath, $item->getPerms() & 0777);
+        }
     }
 
     protected function applyManagerDirectory(string $projectPath, array $options): void

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -326,9 +326,9 @@ class InstallCommand extends Command
     protected function askDatabaseType(): string
     {
         $driverNames = [
+            'sqlite' => 'SQLite',
             'mysql' => 'MySQL or MariaDB',
             'pgsql' => 'PostgreSQL',
-            'sqlite' => 'SQLite',
             'sqlsrv' => 'SQL Server'
         ];
 

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -162,6 +162,30 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->removeTempDir($projectPath);
     }
 
+    public function testFinalizeInstallationRemovesDevelopmentOnlyRootFiles(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $projectPath = $this->makeTempProjectDir();
+        @mkdir($projectPath . '/core/database/seeders', 0755, true);
+
+        file_put_contents($projectPath . '/AGENTS.md', "dev notes\n");
+        file_put_contents($projectPath . '/publiccode.yml', "publiccode\n");
+
+        $cmd->finalizeInstallationPublic($projectPath, [
+            'install_in_current_dir' => true,
+            'admin' => [
+                'directory' => 'manager',
+            ],
+        ]);
+
+        $this->assertFileDoesNotExist($projectPath . '/AGENTS.md');
+        $this->assertFileDoesNotExist($projectPath . '/publiccode.yml');
+        $this->assertFileExists($projectPath . '/core/.install');
+
+        $this->removeTempDir($projectPath);
+    }
+
     private function makeTempProjectDir(): string
     {
         $base = rtrim(sys_get_temp_dir(), '/\\');
@@ -212,5 +236,10 @@ final class TestableInstallCommand extends InstallCommand
     public function applyManagerDirectoryPublic(string $projectPath, array $options): void
     {
         $this->applyManagerDirectory($projectPath, $options);
+    }
+
+    public function finalizeInstallationPublic(string $projectPath, array $options): void
+    {
+        $this->finalizeInstallation($projectPath, $options);
     }
 }


### PR DESCRIPTION
## Summary
- add bundled inline plugins/modules as a first-class extras source with base items preselected by default
- keep managed Composer extras as their own source and add a legacy Store source backed by extras.evo.im
- route bundled and legacy selections through source-aware install paths instead of the old flat artisan-only extras flow

## Validation
- go test ./...
- php -l internal/engine/install/extras_helper.php

## Notes
- legacy Store install now distinguishes simple fast-style payloads from fuller multi-component imports
- full legacy imports cover templates, TVs, module dependencies, and base `setup.sql` when present
- `setup.data.sql` still stays out of the default path until we add an explicit sample-data choice