### PR TITLE
fix(installer): [UPD] bootstrap install migration history on upgrade

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -2450,6 +2450,11 @@ class InstallCommand extends Command
             return;
         }
 
+        $registeredHistory = $this->bootstrapInstallMigrationHistory($projectPath, $options['database'] ?? []);
+        if ($registeredHistory > 0) {
+            $this->tui->addLog("Registered {$registeredHistory} historical install migration(s) before upgrade.");
+        }
+
         $this->tui->addLog("Using migrations from: {$migrationPath}");
 
         $sessionDir = $projectPath . '/core/storage/sessions';
@@ -2534,6 +2539,94 @@ class InstallCommand extends Command
             $this->tui->addLog('Migration/package discovery failed: ' . $e->getMessage(), 'error');
             throw new \RuntimeException("Failed to complete migrations or package discovery. Please run 'php core/artisan migrate' and 'php core/artisan package:discover' manually.");
         }
+    }
+
+    protected function bootstrapInstallMigrationHistory(
+        string $projectPath,
+        array $dbConfig,
+        string $baselineMigration = '2025_12_25_000000_initial_schema'
+    ): int {
+        $migrationsPath = rtrim($projectPath, '/\\') . '/install/stubs/migrations';
+        if (!is_dir($migrationsPath)) {
+            return 0;
+        }
+
+        $dbConfigForOps = $this->getDatabaseConfigForOperations($projectPath, $dbConfig);
+        $type = (string) ($dbConfigForOps['type'] ?? ($dbConfig['type'] ?? 'mysql'));
+        $prefix = (string) ($dbConfigForOps['prefix'] ?? ($dbConfig['prefix'] ?? 'evo_'));
+        $migrationsTable = $prefix . 'migrations_install';
+        $guardTable = $prefix . 'active_user_locks';
+
+        try {
+            $dbh = $this->createConnection($dbConfigForOps, true);
+        } catch (\Throwable $exception) {
+            return 0;
+        }
+
+        if (!$this->tableExists($dbh, $type, $migrationsTable) || !$this->tableExists($dbh, $type, $guardTable)) {
+            return 0;
+        }
+
+        $registered = $this->fetchMigrationHistory($dbh, $type, $migrationsTable);
+        if (!in_array($baselineMigration, $registered, true)) {
+            return 0;
+        }
+
+        $historical = [];
+        foreach (glob($migrationsPath . '/*.php') as $migrationFile) {
+            $migration = basename($migrationFile, '.php');
+            if (strcmp($migration, $baselineMigration) < 0 && !in_array($migration, $registered, true)) {
+                $historical[] = $migration;
+            }
+        }
+
+        if ($historical === []) {
+            return 0;
+        }
+
+        sort($historical);
+        $batch = $this->fetchMaxMigrationBatch($dbh, $type, $migrationsTable);
+        $statement = $dbh->prepare(
+            'INSERT INTO ' . $this->quoteIdentifier($type, $migrationsTable) . ' (migration, batch) VALUES (?, ?)'
+        );
+
+        foreach ($historical as $migration) {
+            $statement->execute([$migration, $batch]);
+        }
+
+        return count($historical);
+    }
+
+    protected function tableExists(\PDO $dbh, string $type, string $table): bool
+    {
+        try {
+            $dbh->query('SELECT 1 FROM ' . $this->quoteIdentifier($type, $table) . ' LIMIT 1');
+            return true;
+        } catch (\Throwable $exception) {
+            return false;
+        }
+    }
+
+    protected function fetchMigrationHistory(\PDO $dbh, string $type, string $table): array
+    {
+        $statement = $dbh->query('SELECT migration FROM ' . $this->quoteIdentifier($type, $table));
+        if ($statement === false) {
+            return [];
+        }
+
+        $rows = $statement->fetchAll(\PDO::FETCH_COLUMN);
+        return array_values(array_filter(array_map('strval', $rows)));
+    }
+
+    protected function fetchMaxMigrationBatch(\PDO $dbh, string $type, string $table): int
+    {
+        $statement = $dbh->query('SELECT MAX(batch) FROM ' . $this->quoteIdentifier($type, $table));
+        if ($statement === false) {
+            return 1;
+        }
+
+        $batch = $statement->fetchColumn();
+        return max(1, (int) $batch);
     }
 
     protected function patchPostgresInetDefaultsInMigrations(string $projectPath): void

--- a/tests/Unit/InstallCommandMigrationBootstrapTest.php
+++ b/tests/Unit/InstallCommandMigrationBootstrapTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace EvolutionCMS\Installer\Tests\Unit;
+
+use EvolutionCMS\Installer\Commands\InstallCommand;
+use PHPUnit\Framework\TestCase;
+
+final class InstallCommandMigrationBootstrapTest extends TestCase
+{
+    public function testBootstrapInstallMigrationHistoryRegistersOlderStubMigrations(): void
+    {
+        $cmd = new TestableMigrationBootstrapInstallCommand();
+        $projectPath = $this->makeTempProjectDir();
+        $databasePath = $projectPath . '/database.sqlite';
+
+        @mkdir($projectPath . '/install/stubs/migrations', 0755, true);
+        file_put_contents($projectPath . '/install/stubs/migrations/2018_06_29_182342_create_role_permissions_table.php', "<?php\n");
+        file_put_contents($projectPath . '/install/stubs/migrations/2020_10_08_112342_remove_column_from_role_table.php', "<?php\n");
+        file_put_contents($projectPath . '/install/stubs/migrations/2025_12_25_000000_initial_schema.php', "<?php\n");
+        file_put_contents($projectPath . '/install/stubs/migrations/2026_03_29_000000_create_file_groups_table.php', "<?php\n");
+
+        $dbh = new \PDO('sqlite:' . $databasePath);
+        $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $dbh->exec('CREATE TABLE "evo_migrations_install" (migration VARCHAR(255) NOT NULL, batch INTEGER NOT NULL)');
+        $dbh->exec('CREATE TABLE "evo_active_user_locks" (id INTEGER PRIMARY KEY AUTOINCREMENT)');
+        $dbh->exec('INSERT INTO "evo_migrations_install" (migration, batch) VALUES ("2025_12_25_000000_initial_schema", 1)');
+
+        $inserted = $cmd->bootstrapInstallMigrationHistoryPublic($projectPath, [
+            'type' => 'sqlite',
+            'name' => $databasePath,
+            'prefix' => 'evo_',
+        ]);
+
+        $this->assertSame(2, $inserted);
+
+        $history = $dbh->query('SELECT migration, batch FROM "evo_migrations_install" ORDER BY migration')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertSame([
+            ['migration' => '2018_06_29_182342_create_role_permissions_table', 'batch' => 1],
+            ['migration' => '2020_10_08_112342_remove_column_from_role_table', 'batch' => 1],
+            ['migration' => '2025_12_25_000000_initial_schema', 'batch' => 1],
+        ], $history);
+
+        $this->removeTempDir($projectPath);
+    }
+
+    public function testBootstrapInstallMigrationHistorySkipsWhenBaselineIsMissing(): void
+    {
+        $cmd = new TestableMigrationBootstrapInstallCommand();
+        $projectPath = $this->makeTempProjectDir();
+        $databasePath = $projectPath . '/database.sqlite';
+
+        @mkdir($projectPath . '/install/stubs/migrations', 0755, true);
+        file_put_contents($projectPath . '/install/stubs/migrations/2018_06_29_182342_create_role_permissions_table.php', "<?php\n");
+        file_put_contents($projectPath . '/install/stubs/migrations/2025_12_25_000000_initial_schema.php', "<?php\n");
+
+        $dbh = new \PDO('sqlite:' . $databasePath);
+        $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $dbh->exec('CREATE TABLE "evo_migrations_install" (migration VARCHAR(255) NOT NULL, batch INTEGER NOT NULL)');
+        $dbh->exec('CREATE TABLE "evo_active_user_locks" (id INTEGER PRIMARY KEY AUTOINCREMENT)');
+
+        $inserted = $cmd->bootstrapInstallMigrationHistoryPublic($projectPath, [
+            'type' => 'sqlite',
+            'name' => $databasePath,
+            'prefix' => 'evo_',
+        ]);
+
+        $this->assertSame(0, $inserted);
+        $count = (int) $dbh->query('SELECT COUNT(*) FROM "evo_migrations_install"')->fetchColumn();
+        $this->assertSame(0, $count);
+
+        $this->removeTempDir($projectPath);
+    }
+
+    private function makeTempProjectDir(): string
+    {
+        $base = rtrim(sys_get_temp_dir(), '/\\');
+        $dir = $base . DIRECTORY_SEPARATOR . 'evo-installer-bootstrap-' . bin2hex(random_bytes(8));
+        if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            $this->fail("Unable to create temp dir: {$dir}");
+        }
+        return $dir;
+    }
+
+    private function removeTempDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}
+
+final class TestableMigrationBootstrapInstallCommand extends InstallCommand
+{
+    public function bootstrapInstallMigrationHistoryPublic(string $projectPath, array $dbConfig): int
+    {
+        return $this->bootstrapInstallMigrationHistory($projectPath, $dbConfig);
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap `migrations_install` history before running install stub migrations during update-like installer runs
- keep the fix bounded to the standalone installer migration path instead of depending on the legacy web installer helper
- add a sqlite unit test that locks the baseline-row upgrade scenario

## Validation
- `./vendor-php/bin/phpunit tests/Unit/InstallCommandMigrationBootstrapTest.php`
- `./vendor-php/bin/phpunit tests/Unit/InstallCommandAdminDirectoryTest.php`
