### PR TITLE
feat(installer): [ADD] project preset install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This command will:
 
 ```bash
 evo install my-project --preset=evolution
+evo install my-project --preset=evolution-cms-presets/default --preset-ref=main
 evo install my-project --db-type=mysql
 evo install my-project --db-host=localhost --db-name=evo_db
 evo install my-project --admin-username=admin --admin-email=admin@example.com
@@ -118,7 +119,8 @@ evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (o
 
 ### Available Options
 
-- `--preset`: The preset to use (default: `evolution`)
+- `--preset`: Project-layer preset source. Use `evolution` or omit it for core-only install; use `default`, `evolution-cms-presets/default`, a Git URL, or a local path to apply a project preset.
+- `--preset-ref`: Git branch/tag for the project-layer preset.
 - `--db-type`: Database type (`mysql`, `pgsql`, `sqlite`, or `sqlsrv`)
 - `--db-host`: Database host (default: `localhost`, not used for SQLite)
 - `--db-port`: Database port (defaults: 3306 for MySQL, 5432 for PostgreSQL, 1433 for SQL Server)
@@ -154,6 +156,8 @@ evo install demo \
   --admin-password=123456 \
   --admin-directory=manager \
   --language=uk \
+  --preset=evolution-cms-presets/default \
+  --preset-ref=main \
   --composer-clear-cache \
   --github-pat=YOUR_GITHUB_PAT \
   --extras=sTask@main,sSeo
@@ -163,9 +167,41 @@ Notes:
 - `--cli` skips the Extras wizard prompt; use `--extras` to auto-install.
 - `--extras` works in both TUI and CLI; when provided, the wizard is skipped and installation starts immediately.
 
-## Presets
+## Project Presets
 
-### Evolution Preset (Default)
+The installer separates the target project from the preset source.
+
+For example, this installs a new project into `dmi3yy.com`, then copies the `evolution-cms-presets/default` project layer into that project:
+
+```bash
+evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
+  --cli \
+  --branch=3.5.x \
+  --db-type=sqlite \
+  --db-name=database.sqlite \
+  --admin-username=admin \
+  --admin-email=admin@example.com \
+  --admin-password=change-me \
+  --admin-directory=manager \
+  --language=uk \
+  --preset=evolution-cms-presets/default \
+  --preset-ref=main \
+  --composer-update \
+  --composer-clear-cache
+```
+
+`--preset=evolution-cms-presets/default` means "copy this preset as the bootstrap project layer." It does not define the future GitHub identity of the created site. The target directory or its own Git remote can still be `dmi3yy/dmi3yy.com`.
+
+Accepted preset sources:
+
+- `default` resolves to `https://github.com/evolution-cms-presets/default.git`
+- `evolution-cms-presets/default` resolves to `https://github.com/evolution-cms-presets/default.git`
+- full Git URLs are used as-is
+- local paths are used as-is
+
+Use `--preset-ref=<branch-or-tag>` to install a specific preset branch or tag.
+
+### Evolution Core Only
 
 Standard Evolution CMS installation with all core features.
 
@@ -175,9 +211,9 @@ evo install my-project
 evo install my-project --preset=evolution
 ```
 
-### Custom Presets
+### Custom Project Presets
 
-You can create custom presets by extending the `Preset` class. See the `src/Presets/` directory for examples.
+Project presets are applied through the installed Evolution CMS `core/artisan preset:install` command after the core installation and database setup complete.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -230,11 +230,14 @@ Presets can declare required Extras in `core/custom/preset.json`. Required Extra
 }
 ```
 
+For example, `evolution-cms-presets/blog-daisyui` uses this manifest to require `eTinyMCE` and `sSeo` during installation.
+
 Accepted preset sources:
 
 - `default` resolves to `https://github.com/evolution-cms-presets/default.git`
 - `evolution-cms-presets/default` resolves to `https://github.com/evolution-cms-presets/default.git`
 - `evolution-cms-presets/default@dev` resolves to the same preset repository with Git ref `dev`
+- `evolution-cms-presets/blog-daisyui` resolves to the official blog starter preset
 - `owner/private-preset` can be entered in TUI as a custom source when your Git environment can access it
 - full Git URLs are used as-is; add `#dev` when you need a URL ref
 - local paths are used as-is

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ composer global update evolution-cms/installer
 ### Create a new Evolution CMS project
 
 ```bash
-evo install my-project
+evo install my-project --branch=3.5.x --preset=evolution-cms-presets/default
 ```
 
 This command will:
@@ -96,6 +96,7 @@ This command will:
 - Configure the database connection
 - Run migrations and seeders
 - Create the admin user
+- Apply the default project-layer preset
 
 ### Command Options
 
@@ -109,7 +110,6 @@ evo install my-project --admin-username=admin --admin-email=admin@example.com
 evo install my-project --admin-directory=manager
 evo install my-project --language=en
 evo install my-project --branch=develop  # Install from specific Git branch
-evo install my-project --git  # Initialize a Git repository
 evo install my-project --force  # Force install even if directory exists
 evo install my-project --cli --log  # Non-interactive mode + write log.md
 evo install my-project --composer-update  # Use composer update during setup
@@ -133,7 +133,6 @@ evo install my-project --extras=sTask,sSeo  # Install extras after setup (option
 - `--admin-directory`: Admin directory name (default: `manager`)
 - `--language`: Installation language (default: `en`)
 - `--branch`: Install from specific Git branch (e.g., `3.5.x`, `develop`, `nightly`, `main`) instead of latest release
-- `--git`: Initialize a Git repository and create initial commit
 - `--force`: Force install even if directory exists
 - `--log`: Always write installer log to `log.md`
 - `--cli`: Run in non-interactive CLI mode (no TUI)
@@ -156,10 +155,7 @@ evo install demo \
   --admin-password=123456 \
   --admin-directory=manager \
   --language=uk \
-  --preset=evolution-cms-presets/default \
-  --composer-clear-cache \
-  --github-pat=YOUR_GITHUB_PAT \
-  --extras=sTask,sSeo
+  --preset=evolution-cms-presets/default
 ```
 
 Notes:
@@ -171,7 +167,15 @@ Notes:
 
 The installer separates the target project from the preset source.
 
-For example, this installs a new project into `dmi3yy.com`, then copies the `evolution-cms-presets/default` project layer into that project:
+For TUI installs, pass only the branch and preset when you want the installer to ask for database, admin user, language, and optional Extras:
+
+```bash
+evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
+  --branch=3.5.x \
+  --preset=evolution-cms-presets/default
+```
+
+For CLI installs, provide all required answers up front. This installs a new project into `dmi3yy.com`, then copies the `evolution-cms-presets/default` project layer into that project:
 
 ```bash
 evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
@@ -184,12 +188,12 @@ evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
   --admin-password=change-me \
   --admin-directory=manager \
   --language=uk \
-  --preset=evolution-cms-presets/default \
-  --composer-update \
-  --composer-clear-cache
+  --preset=evolution-cms-presets/default
 ```
 
 `--preset=evolution-cms-presets/default` means "copy this preset as the bootstrap project layer." It does not define the future GitHub identity of the created site. The target directory or its own Git remote can still be `dmi3yy/dmi3yy.com`.
+
+The default preset does not install Extras. Use `--extras=sTask,sSeo` only when you intentionally want those packages in the project.
 
 Accepted preset sources:
 
@@ -276,7 +280,9 @@ Requirements: Go (see `go` version in `go.mod`).
 From `installer/`:
 
 ```bash
-go run ./cmd/evo install
+go run ./cmd/evo install /tmp/evo-default-check \
+  --branch=3.5.x \
+  --preset=evolution-cms-presets/default
 # or
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -219,18 +219,17 @@ evo install /path/to/my-site \
 
 The default preset does not install Extras. Use `--extras=sTask,sSeo` only when you intentionally want those packages in the project.
 
-Presets can declare required Extras in `core/custom/preset.json`. Required Extras are automatically selected after the preset is applied, stay locked in the TUI, and are still installed when the user chooses to skip optional Extras:
+Presets can declare required managed Composer Extras in `core/custom/composer.json`. The installer reads those Composer requirements after the preset is applied, matches them against the managed Extras catalog, then runs the Extras installer so provider discovery, asset publishing, migrations, and cache clearing still happen. Required Extras are automatically selected after the preset is applied, stay locked in the TUI, and are still installed when the user chooses to skip optional Extras:
 
 ```json
 {
-  "name": "blog-daisyui",
-  "extras": {
-    "required": ["eTinyMCE", "sSeo"]
+  "require": {
+    "evolution-cms/etinymce": "*"
   }
 }
 ```
 
-For example, `evolution-cms-presets/blog-daisyui` uses this manifest to require `eTinyMCE` and `sSeo` during installation.
+Legacy or non-Composer required Extras can still be described in `core/custom/preset.json` when needed, but Composer package dependencies should live in `core/custom/composer.json`.
 
 Accepted preset sources:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ This command will:
 
 ```bash
 evo install my-project --preset=evolution
-evo install my-project --preset=evolution-cms-presets/default --preset-ref=main
+evo install my-project --preset=evolution-cms-presets/default
+evo install my-project --preset=evolution-cms-presets/default@dev
 evo install my-project --db-type=mysql
 evo install my-project --db-host=localhost --db-name=evo_db
 evo install my-project --admin-username=admin --admin-email=admin@example.com
@@ -119,8 +120,7 @@ evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (o
 
 ### Available Options
 
-- `--preset`: Project-layer preset source. Use `evolution` or omit it for core-only install; use `default`, `evolution-cms-presets/default`, a Git URL, or a local path to apply a project preset.
-- `--preset-ref`: Git branch/tag for the project-layer preset.
+- `--preset`: Project-layer preset spec. Use `evolution` or omit it for core-only install; use `default`, `evolution-cms-presets/default`, `evolution-cms-presets/default@dev`, a Git URL, or a local path to apply a project preset.
 - `--db-type`: Database type (`mysql`, `pgsql`, `sqlite`, or `sqlsrv`)
 - `--db-host`: Database host (default: `localhost`, not used for SQLite)
 - `--db-port`: Database port (defaults: 3306 for MySQL, 5432 for PostgreSQL, 1433 for SQL Server)
@@ -157,7 +157,6 @@ evo install demo \
   --admin-directory=manager \
   --language=uk \
   --preset=evolution-cms-presets/default \
-  --preset-ref=main \
   --composer-clear-cache \
   --github-pat=YOUR_GITHUB_PAT \
   --extras=sTask@main,sSeo
@@ -185,7 +184,6 @@ evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
   --admin-directory=manager \
   --language=uk \
   --preset=evolution-cms-presets/default \
-  --preset-ref=main \
   --composer-update \
   --composer-clear-cache
 ```
@@ -196,10 +194,15 @@ Accepted preset sources:
 
 - `default` resolves to `https://github.com/evolution-cms-presets/default.git`
 - `evolution-cms-presets/default` resolves to `https://github.com/evolution-cms-presets/default.git`
-- full Git URLs are used as-is
+- `evolution-cms-presets/default@dev` resolves to the same preset repository with Git ref `dev`
+- full Git URLs are used as-is; add `#dev` when you need a URL ref
 - local paths are used as-is
 
-Use `--preset-ref=<branch-or-tag>` to install a specific preset branch or tag.
+Use a branch or tag suffix only when you need to install a non-default preset ref. Local preset development can point directly at a checkout:
+
+```bash
+evo install /tmp/my-site --preset=/Users/dmi3yy/PhpstormProjects/Extras/Presets/default
+```
 
 ### Evolution Core Only
 

--- a/README.md
+++ b/README.md
@@ -170,15 +170,15 @@ The installer separates the target project from the preset source.
 For TUI installs, pass only the branch and preset when you want the installer to ask for database, admin user, language, and optional Extras:
 
 ```bash
-evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
+evo install /path/to/my-site \
   --branch=3.5.x \
   --preset=evolution-cms-presets/default
 ```
 
-For CLI installs, provide all required answers up front. This installs a new project into `dmi3yy.com`, then copies the `evolution-cms-presets/default` project layer into that project:
+For CLI installs, provide all required answers up front. This installs a new project into the target directory, then copies the `evolution-cms-presets/default` project layer into that project:
 
 ```bash
-evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
+evo install /path/to/my-site \
   --cli \
   --branch=3.5.x \
   --db-type=sqlite \
@@ -191,7 +191,7 @@ evo install /Users/dmi3yy/PhpstormProjects/Extras/dmi3yy.com \
   --preset=evolution-cms-presets/default
 ```
 
-`--preset=evolution-cms-presets/default` means "copy this preset as the bootstrap project layer." It does not define the future GitHub identity of the created site. The target directory or its own Git remote can still be `dmi3yy/dmi3yy.com`.
+`--preset=evolution-cms-presets/default` means "copy this preset as the bootstrap project layer." It does not define the future GitHub identity of the created site. The target directory or its own Git remote can still be your own project repository.
 
 The default preset does not install Extras. Use `--extras=sTask,sSeo` only when you intentionally want those packages in the project.
 
@@ -206,7 +206,7 @@ Accepted preset sources:
 Use a branch or tag suffix only when you need to install a non-default preset ref. Local preset development can point directly at a checkout:
 
 ```bash
-evo install /tmp/my-site --preset=/Users/dmi3yy/PhpstormProjects/Extras/Presets/default
+evo install /path/to/my-site --preset=/path/to/default-preset
 ```
 
 ### Evolution Core Only

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ evo install /path/to/my-site \
 
 The default preset does not install Extras. Use `--extras=sTask,sSeo` only when you intentionally want those packages in the project.
 
+Presets can declare required Extras in `core/custom/preset.json`. Required Extras are automatically selected after the preset is applied, stay locked in the TUI, and are still installed when the user chooses to skip optional Extras:
+
+```json
+{
+  "name": "blog-daisyui",
+  "extras": {
+    "required": ["eTinyMCE", "sSeo"]
+  }
+}
+```
+
 Accepted preset sources:
 
 - `default` resolves to `https://github.com/evolution-cms-presets/default.git`

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ evo install my-project --composer-update  # Use composer update during setup
 evo install my-project --composer-clear-cache  # Clear Composer cache before install
 evo install my-project --github-pat=TOKEN  # GitHub PAT for API requests
 evo install my-project --extras=sTask,sSeo  # Install extras after setup (optional)
+evo install my-project --extras=legacy-store:84@1.12.2  # Install a Legacy Store package by ID
 ```
 
 ### Available Options
@@ -145,7 +146,7 @@ evo install my-project --extras=sTask,sSeo  # Install extras after setup (option
 - `--composer-clear-cache`: Clear Composer cache before install
 - `--composer-update`: Use `composer update` instead of `composer install` during setup
 - `--github-pat` / `--github_pat`: GitHub PAT token for API requests (avoids GitHub rate limits)
-- `--extras`: Comma-separated extras to install after setup (e.g., `sTask,sSeo`; use `sTask@main` only when you want to pin a version/branch)
+- `--extras`: Comma-separated extras to install after setup. Managed extras can be passed by name (for example `sTask,sSeo`) and are installed with `*` unless you pin a version. Legacy Store packages can be passed by ID (for example `legacy-store:84@1.12.2`).
 
 ### CLI Example (Non-interactive)
 
@@ -164,9 +165,10 @@ evo install demo \
 ```
 
 Notes:
-- `--cli` skips the Extras wizard prompt; use `--extras` to auto-install.
-- `--extras` works in both TUI and CLI; when provided, the wizard is skipped and installation starts immediately.
+- `--cli` is non-interactive; use `--extras` to auto-install Extras.
+- `--extras` works in both TUI and CLI; when provided, the Extras selection screen is skipped and installation starts immediately.
 - Extras without an explicit `@version` are installed with Composer constraint `*`, so later Composer updates can pick up newer package versions.
+- Legacy Store packages are selected by their catalog ID in CLI mode, e.g. `--extras=legacy-store:84@1.12.2`.
 
 ## Project Presets
 
@@ -237,10 +239,10 @@ evo install /path/to/my-site --preset=/path/to/default-preset
 Standard Evolution CMS installation with all core features.
 
 ```bash
-evo install my-project
-# or
 evo install my-project --preset=evolution
 ```
+
+In TUI mode, omit `--preset` and keep the default `No project preset (Evolution core only)` choice.
 
 ### Custom Project Presets
 
@@ -267,11 +269,12 @@ Project presets are applied through the installed Evolution CMS `core/artisan pr
 
 ### Managed Extras Wizard (TUI)
 
-- **Post-install prompt**: After the success screen, the installer asks whether to install additional Extras.
-- **Selection UI**: Shows the full managed Extras list (type 0, install via Composer) with checkboxes, versions, and descriptions.
+- **Post-install selection**: After the core installation, the installer opens the Extras selection screen directly with default Extras preselected.
+- **Selection UI**: Shows bundled defaults and managed Extras first, with checkboxes, versions, descriptions, and search.
+- **Legacy Store**: Legacy Store packages are hidden behind the `Show Legacy Store` action so the main list stays focused.
 - **Batch install**: Installs selected Extras one-by-one via `php artisan extras extras <Name> *` by default and shows progress/status.
 - **Post steps**: Runs `php artisan migrate` once after all Extras, then `php artisan cache:clear-full`.
-- **Flow**: Install -> Success screen -> Prompt -> Extras selection -> Progress -> Summary
+- **Flow**: Install -> Extras selection -> Progress -> Summary
 
 ### Inspired by Docker Implementation
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ evo install my-project --extras=legacy-store:84@1.12.2  # Install a Legacy Store
 - `--composer-clear-cache`: Clear Composer cache before install
 - `--composer-update`: Use `composer update` instead of `composer install` during setup
 - `--github-pat` / `--github_pat`: GitHub PAT token for API requests (avoids GitHub rate limits)
-- `--extras`: Comma-separated extras to install after setup. Managed extras can be passed by name (for example `sTask,sSeo`) and are installed with `*` unless you pin a version. Legacy Store packages can be passed by ID (for example `legacy-store:84@1.12.2`).
+- `--extras`: Comma-separated extras to install after setup. Managed extras can be passed by name (for example `sTask,sSeo`) and released packages are installed with `*` unless you pin a version. Dev-only managed packages use their default branch constraint, for example `dev-main`. Legacy Store packages can be passed by ID (for example `legacy-store:84@1.12.2`).
 
 ### CLI Example (Non-interactive)
 
@@ -167,7 +167,7 @@ evo install demo \
 Notes:
 - `--cli` is non-interactive; use `--extras` to auto-install Extras.
 - `--extras` works in both TUI and CLI; when provided, the Extras selection screen is skipped and installation starts immediately.
-- Extras without an explicit `@version` are installed with Composer constraint `*`, so later Composer updates can pick up newer package versions.
+- Released Extras without an explicit `@version` are installed with Composer constraint `*`, so later Composer updates can pick up newer package versions. Dev-only Extras without releases use their default branch constraint, for example `dev-main`.
 - Legacy Store packages are selected by their catalog ID in CLI mode, e.g. `--extras=legacy-store:84@1.12.2`.
 
 ## Project Presets
@@ -272,7 +272,7 @@ Project presets are applied through the installed Evolution CMS `core/artisan pr
 - **Post-install selection**: After the core installation, the installer opens the Extras selection screen directly with default Extras preselected.
 - **Selection UI**: Shows bundled defaults and managed Extras first, with checkboxes, versions, descriptions, and search.
 - **Legacy Store**: Legacy Store packages are hidden behind the `Show Legacy Store` action so the main list stays focused.
-- **Batch install**: Installs selected Extras one-by-one via `php artisan extras extras <Name> *` by default and shows progress/status.
+- **Batch install**: Installs selected Extras one-by-one via `php artisan extras extras <Name> <version>` and shows progress/status. Released managed packages default to `*`; dev-only packages default to their branch constraint such as `dev-main`.
 - **Post steps**: Runs `php artisan migrate` once after all Extras, then `php artisan cache:clear-full`.
 - **Flow**: Install -> Extras selection -> Progress -> Summary
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ evo install my-project --cli --log  # Non-interactive mode + write log.md
 evo install my-project --composer-update  # Use composer update during setup
 evo install my-project --composer-clear-cache  # Clear Composer cache before install
 evo install my-project --github-pat=TOKEN  # GitHub PAT for API requests
-evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (optional)
+evo install my-project --extras=sTask,sSeo  # Install extras after setup (optional)
 ```
 
 ### Available Options
@@ -141,7 +141,7 @@ evo install my-project --extras=sTask@main,sSeo  # Install extras after setup (o
 - `--composer-clear-cache`: Clear Composer cache before install
 - `--composer-update`: Use `composer update` instead of `composer install` during setup
 - `--github-pat` / `--github_pat`: GitHub PAT token for API requests (avoids GitHub rate limits)
-- `--extras`: Comma-separated extras to install after setup (e.g., `sTask@main,sSeo`)
+- `--extras`: Comma-separated extras to install after setup (e.g., `sTask,sSeo`; use `sTask@main` only when you want to pin a version/branch)
 
 ### CLI Example (Non-interactive)
 
@@ -159,12 +159,13 @@ evo install demo \
   --preset=evolution-cms-presets/default \
   --composer-clear-cache \
   --github-pat=YOUR_GITHUB_PAT \
-  --extras=sTask@main,sSeo
+  --extras=sTask,sSeo
 ```
 
 Notes:
 - `--cli` skips the Extras wizard prompt; use `--extras` to auto-install.
 - `--extras` works in both TUI and CLI; when provided, the wizard is skipped and installation starts immediately.
+- Extras without an explicit `@version` are installed with Composer constraint `*`, so later Composer updates can pick up newer package versions.
 
 ## Project Presets
 
@@ -241,7 +242,7 @@ Project presets are applied through the installed Evolution CMS `core/artisan pr
 
 - **Post-install prompt**: After the success screen, the installer asks whether to install additional Extras.
 - **Selection UI**: Shows the full managed Extras list (type 0, install via Composer) with checkboxes, versions, and descriptions.
-- **Batch install**: Installs selected Extras one-by-one via `php artisan extras extras <Name>` and shows progress/status.
+- **Batch install**: Installs selected Extras one-by-one via `php artisan extras extras <Name> *` by default and shows progress/status.
 - **Post steps**: Runs `php artisan migrate` once after all Extras, then `php artisan cache:clear-full`.
 - **Flow**: Install -> Success screen -> Prompt -> Extras selection -> Progress -> Summary
 

--- a/README.md
+++ b/README.md
@@ -84,26 +84,31 @@ composer global update evolution-cms/installer
 ### Create a new Evolution CMS project
 
 ```bash
-evo install my-project --branch=3.5.x --preset=evolution-cms-presets/default
+evo install
 ```
 
 This command will:
 - Validate PHP version compatibility
+- Prompt you for the target installation directory when it was not passed as an argument
 - Prompt you for database configuration (with connection testing)
 - Prompt you for admin user credentials and directory
 - Prompt you for installation language
+- Prompt you to choose a project preset from `evolution-cms-presets` or enter a custom preset source
 - Download and install Evolution CMS (latest compatible version or from specific branch)
 - Configure the database connection
 - Run migrations and seeders
 - Create the admin user
-- Apply the default project-layer preset
+- Apply the selected project-layer preset
 
 ### Command Options
 
 ```bash
+evo install
+evo install my-project
 evo install my-project --preset=evolution
 evo install my-project --preset=evolution-cms-presets/default
 evo install my-project --preset=evolution-cms-presets/default@dev
+evo install my-project --preset=evolution-cms-presets/default-daisyui
 evo install my-project --db-type=mysql
 evo install my-project --db-host=localhost --db-name=evo_db
 evo install my-project --admin-username=admin --admin-email=admin@example.com
@@ -120,7 +125,7 @@ evo install my-project --extras=sTask,sSeo  # Install extras after setup (option
 
 ### Available Options
 
-- `--preset`: Project-layer preset spec. Use `evolution` or omit it for core-only install; use `default`, `evolution-cms-presets/default`, `evolution-cms-presets/default@dev`, a Git URL, or a local path to apply a project preset.
+- `--preset`: Project-layer preset spec. In TUI mode, omit it to choose from the `evolution-cms-presets` catalog or enter a custom source. In CLI mode, omit it for core-only install. Use `evolution`, `default`, `evolution-cms-presets/default`, `evolution-cms-presets/default@dev`, a Git URL, or a local path.
 - `--db-type`: Database type (`mysql`, `pgsql`, `sqlite`, or `sqlsrv`)
 - `--db-host`: Database host (default: `localhost`, not used for SQLite)
 - `--db-port`: Database port (defaults: 3306 for MySQL, 5432 for PostgreSQL, 1433 for SQL Server)
@@ -167,12 +172,29 @@ Notes:
 
 The installer separates the target project from the preset source.
 
-For TUI installs, pass only the branch and preset when you want the installer to ask for database, admin user, language, and optional Extras:
+For TUI installs, you can run the installer with no arguments and choose the target directory, database, admin user, language, project preset, and optional Extras inside the wizard:
+
+```bash
+evo install
+```
+
+If you already know the target directory or branch, pass only those values and let TUI ask the rest:
+
+```bash
+evo install /path/to/my-site --branch=3.5.x
+```
+
+When `--preset` is omitted in TUI mode, the installer fetches public repositories from `https://github.com/evolution-cms-presets/` and shows them as preset choices. The same screen also includes:
+
+- `Custom repository, Git URL, or local path` for private presets or local development checkouts
+- `Evolution core only (no project preset)` for a plain core install
+
+You can still pass a preset directly when you want to skip the preset picker:
 
 ```bash
 evo install /path/to/my-site \
   --branch=3.5.x \
-  --preset=evolution-cms-presets/default
+  --preset=evolution-cms-presets/default-daisyui
 ```
 
 For CLI installs, provide all required answers up front. This installs a new project into the target directory, then copies the `evolution-cms-presets/default` project layer into that project:
@@ -200,6 +222,7 @@ Accepted preset sources:
 - `default` resolves to `https://github.com/evolution-cms-presets/default.git`
 - `evolution-cms-presets/default` resolves to `https://github.com/evolution-cms-presets/default.git`
 - `evolution-cms-presets/default@dev` resolves to the same preset repository with Git ref `dev`
+- `owner/private-preset` can be entered in TUI as a custom source when your Git environment can access it
 - full Git URLs are used as-is; add `#dev` when you need a URL ref
 - local paths are used as-is
 
@@ -280,9 +303,9 @@ Requirements: Go (see `go` version in `go.mod`).
 From `installer/`:
 
 ```bash
-go run ./cmd/evo install /tmp/evo-default-check \
-  --branch=3.5.x \
-  --preset=evolution-cms-presets/default
+go run ./cmd/evo install
+# or prefill the Evolution branch and let TUI ask for directory, preset, DB, admin, language, and Extras:
+go run ./cmd/evo install --branch=3.5.x
 # or
 make install
 ```

--- a/cmd/evo/cli.go
+++ b/cmd/evo/cli.go
@@ -49,6 +49,9 @@ func applyCLIDefaults(opt *installengine.Options) error {
 	if strings.TrimSpace(opt.Language) == "" {
 		opt.Language = "en"
 	}
+	if strings.TrimSpace(opt.Preset) == "" {
+		opt.Preset = "evolution"
+	}
 
 	adminEmail := strings.TrimSpace(opt.AdminEmail)
 	if adminEmail == "" {

--- a/cmd/evo/cli.go
+++ b/cmd/evo/cli.go
@@ -231,14 +231,6 @@ func handleCLIQuestion(q domain.QuestionState, actions chan<- domain.Action, can
 		*hadError = true
 		fmt.Fprintln(os.Stderr, "Database connection failed; exiting (no retry in --cli mode).")
 		return true
-	case "extras_prompt":
-		sendAction(actions, domain.Action{
-			Type:       domain.ActionAnswerSelect,
-			QuestionID: q.ID,
-			OptionID:   "no",
-		})
-		fmt.Fprintln(os.Stdout, "Extras installation skipped in --cli mode.")
-		return true
 	default:
 		*hadError = true
 		fmt.Fprintln(os.Stderr, cliMissingInputMessage(q))

--- a/cmd/evo/cli.go
+++ b/cmd/evo/cli.go
@@ -200,6 +200,17 @@ func applyCLIEvent(ev domain.Event, stepLabels map[string]string, actions chan<-
 		}
 	case domain.EventExtras:
 		if p, ok := ev.Payload.(domain.ExtrasState); ok && p.Stage == domain.ExtrasStageSelect {
+			required := requiredExtrasSelections(p.Selections)
+			if len(required) > 0 {
+				sendAction(actions, domain.Action{
+					Type:       domain.ActionExtrasDecision,
+					QuestionID: "extras_select",
+					OptionID:   "install",
+					Extras:     required,
+				})
+				fmt.Fprintln(os.Stdout, "Installing required preset Extras in --cli mode.")
+				return true
+			}
 			sendAction(actions, domain.Action{
 				Type:       domain.ActionExtrasDecision,
 				QuestionID: "extras_select",
@@ -210,6 +221,19 @@ func applyCLIEvent(ev domain.Event, stepLabels map[string]string, actions chan<-
 		}
 	}
 	return false
+}
+
+func requiredExtrasSelections(selections []domain.ExtrasSelection) []domain.ExtrasSelection {
+	if len(selections) == 0 {
+		return nil
+	}
+	out := make([]domain.ExtrasSelection, 0, len(selections))
+	for _, sel := range selections {
+		if sel.Required {
+			out = append(out, sel)
+		}
+	}
+	return out
 }
 
 func handleCLIQuestion(q domain.QuestionState, actions chan<- domain.Action, cancel func(), hadError *bool) bool {

--- a/cmd/evo/main.go
+++ b/cmd/evo/main.go
@@ -298,7 +298,12 @@ func parseExtrasSelections(raw string) ([]domain.ExtrasSelection, error) {
 		if name == "" {
 			return nil, fmt.Errorf("invalid --extras value: %q", part)
 		}
-		out = append(out, domain.ExtrasSelection{Name: name, Version: version})
+		sel := domain.ExtrasSelection{Name: name, Version: version}
+		if strings.Contains(name, ":") {
+			sel.ID = name
+			sel.Name = ""
+		}
+		out = append(out, sel)
 	}
 	return out, nil
 }

--- a/cmd/evo/main.go
+++ b/cmd/evo/main.go
@@ -197,10 +197,6 @@ func runInstall(ctx context.Context, args []string) int {
 		printUsage()
 		return 2
 	}
-	if strings.TrimSpace(installDir) == "" {
-		installDir = "."
-	}
-
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
@@ -233,6 +229,9 @@ func runInstall(ctx context.Context, args []string) int {
 
 	if err := fs.Parse(flagArgs); err != nil {
 		return 2
+	}
+	if strings.TrimSpace(installDir) == "" && *cliMode {
+		installDir = "."
 	}
 	pat := strings.TrimSpace(*githubPat)
 	if pat == "" {
@@ -487,13 +486,13 @@ func printUsage() {
 	fmt.Println("Evolution CMS Installer TUI")
 	fmt.Println("")
 	fmt.Println("Usage:")
-	fmt.Println("  evo install [dir] [flags]  Run TUI installer")
+	fmt.Println("  evo install [dir] [flags]  Run TUI installer; omit dir to choose it in TUI")
 	fmt.Println("  evo version   Print version")
 	fmt.Println("")
 	fmt.Println("Common flags:")
 	fmt.Println("  -f, --force                Force installation even if directory exists")
 	fmt.Println("  --branch=<name>            Install from Git branch (e.g., main or master)")
-	fmt.Println("  --preset=<spec>            Apply project preset (e.g., evolution-cms-presets/default@dev)")
+	fmt.Println("  --preset=<spec>            Apply project preset; omit to choose it in TUI")
 	fmt.Println("  --db-type=<driver>         mysql|pgsql|sqlite|sqlsrv")
 	fmt.Println("  --db-name=<name|path>      Database name (or SQLite file path)")
 	fmt.Println("  --admin-email=<email>      Admin email")

--- a/cmd/evo/main.go
+++ b/cmd/evo/main.go
@@ -208,8 +208,7 @@ func runInstall(ctx context.Context, args []string) int {
 	fs.BoolVar(force, "f", false, "Force installation even if directory exists")
 
 	branch := fs.String("branch", "", "Install from specific Git branch instead of latest release")
-	preset := fs.String("preset", "", "Project-layer preset source (name, owner/repo, Git URL, or local path)")
-	presetRef := fs.String("preset-ref", "", "Git branch/tag for the project-layer preset")
+	preset := fs.String("preset", "", "Project-layer preset spec (name, owner/repo, Git URL, or local path; optional @ref)")
 
 	dbType := fs.String("db-type", "", "Database type (mysql, pgsql, sqlite, sqlsrv)")
 	dbHost := fs.String("db-host", "", "Database host (default: localhost)")
@@ -246,7 +245,6 @@ func runInstall(ctx context.Context, args []string) int {
 		SelfVersion:        Version,
 		Branch:             strings.TrimSpace(*branch),
 		Preset:             strings.TrimSpace(*preset),
-		PresetRef:          strings.TrimSpace(*presetRef),
 		ComposerClearCache: *composerClearCache,
 		ComposerUpdate:     *composerUpdate,
 		DBType:             strings.ToLower(strings.TrimSpace(*dbType)),
@@ -311,7 +309,7 @@ func splitInstallArgs(args []string) (installDir string, flagArgs []string, err 
 
 	expectsValue := func(flag string) bool {
 		switch flag {
-		case "branch", "preset", "preset-ref", "db-type", "db-host", "db-port", "db-name", "db-user", "db-password",
+		case "branch", "preset", "db-type", "db-host", "db-port", "db-name", "db-user", "db-password",
 			"admin-username", "admin-email", "admin-password", "admin-directory", "language", "github-pat", "github_pat", "extras":
 			return true
 		default:
@@ -495,8 +493,7 @@ func printUsage() {
 	fmt.Println("Common flags:")
 	fmt.Println("  -f, --force                Force installation even if directory exists")
 	fmt.Println("  --branch=<name>            Install from Git branch (e.g., main or master)")
-	fmt.Println("  --preset=<source>          Apply project-layer preset (e.g., evolution-cms-presets/default)")
-	fmt.Println("  --preset-ref=<name>        Preset Git branch or tag")
+	fmt.Println("  --preset=<spec>            Apply project preset (e.g., evolution-cms-presets/default@dev)")
 	fmt.Println("  --db-type=<driver>         mysql|pgsql|sqlite|sqlsrv")
 	fmt.Println("  --db-name=<name|path>      Database name (or SQLite file path)")
 	fmt.Println("  --admin-email=<email>      Admin email")

--- a/cmd/evo/main.go
+++ b/cmd/evo/main.go
@@ -208,6 +208,8 @@ func runInstall(ctx context.Context, args []string) int {
 	fs.BoolVar(force, "f", false, "Force installation even if directory exists")
 
 	branch := fs.String("branch", "", "Install from specific Git branch instead of latest release")
+	preset := fs.String("preset", "", "Project-layer preset source (name, owner/repo, Git URL, or local path)")
+	presetRef := fs.String("preset-ref", "", "Git branch/tag for the project-layer preset")
 
 	dbType := fs.String("db-type", "", "Database type (mysql, pgsql, sqlite, sqlsrv)")
 	dbHost := fs.String("db-host", "", "Database host (default: localhost)")
@@ -243,6 +245,8 @@ func runInstall(ctx context.Context, args []string) int {
 		Dir:                installDir,
 		SelfVersion:        Version,
 		Branch:             strings.TrimSpace(*branch),
+		Preset:             strings.TrimSpace(*preset),
+		PresetRef:          strings.TrimSpace(*presetRef),
 		ComposerClearCache: *composerClearCache,
 		ComposerUpdate:     *composerUpdate,
 		DBType:             strings.ToLower(strings.TrimSpace(*dbType)),
@@ -307,7 +311,7 @@ func splitInstallArgs(args []string) (installDir string, flagArgs []string, err 
 
 	expectsValue := func(flag string) bool {
 		switch flag {
-		case "branch", "db-type", "db-host", "db-port", "db-name", "db-user", "db-password",
+		case "branch", "preset", "preset-ref", "db-type", "db-host", "db-port", "db-name", "db-user", "db-password",
 			"admin-username", "admin-email", "admin-password", "admin-directory", "language", "github-pat", "github_pat", "extras":
 			return true
 		default:
@@ -491,6 +495,8 @@ func printUsage() {
 	fmt.Println("Common flags:")
 	fmt.Println("  -f, --force                Force installation even if directory exists")
 	fmt.Println("  --branch=<name>            Install from Git branch (e.g., main or master)")
+	fmt.Println("  --preset=<source>          Apply project-layer preset (e.g., evolution-cms-presets/default)")
+	fmt.Println("  --preset-ref=<name>        Preset Git branch or tag")
 	fmt.Println("  --db-type=<driver>         mysql|pgsql|sqlite|sqlsrv")
 	fmt.Println("  --db-name=<name|path>      Database name (or SQLite file path)")
 	fmt.Println("  --admin-email=<email>      Admin email")

--- a/cmd/evo/main_test.go
+++ b/cmd/evo/main_test.go
@@ -32,3 +32,23 @@ func TestSplitInstallArgsRequiresPresetValue(t *testing.T) {
 		t.Fatal("splitInstallArgs returned nil error for missing --preset value")
 	}
 }
+
+func TestSplitInstallArgsAllowsFlagsWithoutInstallDir(t *testing.T) {
+	installDir, flags, err := splitInstallArgs([]string{"--branch=3.5.x", "--preset=evolution-cms-presets/default-daisyui"})
+	if err != nil {
+		t.Fatalf("splitInstallArgs returned error: %v", err)
+	}
+	if installDir != "" {
+		t.Fatalf("installDir = %q, want empty", installDir)
+	}
+
+	want := []string{"--branch=3.5.x", "--preset=evolution-cms-presets/default-daisyui"}
+	if len(flags) != len(want) {
+		t.Fatalf("flags = %#v, want %#v", flags, want)
+	}
+	for i := range want {
+		if flags[i] != want[i] {
+			t.Fatalf("flags[%d] = %q, want %q", i, flags[i], want[i])
+		}
+	}
+}

--- a/cmd/evo/main_test.go
+++ b/cmd/evo/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestSplitInstallArgsKeepsPresetFlags(t *testing.T) {
+	installDir, flags, err := splitInstallArgs([]string{
+		"/tmp/site",
+		"--preset=evolution-cms-presets/default",
+		"--preset-ref",
+		"main",
+		"--cli",
+	})
+	if err != nil {
+		t.Fatalf("splitInstallArgs returned error: %v", err)
+	}
+	if installDir != "/tmp/site" {
+		t.Fatalf("installDir = %q, want /tmp/site", installDir)
+	}
+
+	want := []string{"--preset=evolution-cms-presets/default", "--preset-ref", "main", "--cli"}
+	if len(flags) != len(want) {
+		t.Fatalf("flags = %#v, want %#v", flags, want)
+	}
+	for i := range want {
+		if flags[i] != want[i] {
+			t.Fatalf("flags[%d] = %q, want %q", i, flags[i], want[i])
+		}
+	}
+}
+
+func TestSplitInstallArgsRequiresPresetValue(t *testing.T) {
+	_, _, err := splitInstallArgs([]string{"/tmp/site", "--preset"})
+	if err == nil {
+		t.Fatal("splitInstallArgs returned nil error for missing --preset value")
+	}
+}

--- a/cmd/evo/main_test.go
+++ b/cmd/evo/main_test.go
@@ -52,3 +52,22 @@ func TestSplitInstallArgsAllowsFlagsWithoutInstallDir(t *testing.T) {
 		}
 	}
 }
+
+func TestParseExtrasSelectionsKeepsLegacyStoreID(t *testing.T) {
+	selections, err := parseExtrasSelections("legacy-store:84@1.12.2,sSeo")
+	if err != nil {
+		t.Fatalf("parseExtrasSelections returned error: %v", err)
+	}
+	if len(selections) != 2 {
+		t.Fatalf("expected 2 selections, got %#v", selections)
+	}
+	if selections[0].ID != "legacy-store:84" {
+		t.Fatalf("expected legacy ID, got %#v", selections[0])
+	}
+	if selections[0].Version != "1.12.2" {
+		t.Fatalf("expected legacy version, got %#v", selections[0])
+	}
+	if selections[1].Name != "sSeo" {
+		t.Fatalf("expected managed name selection, got %#v", selections[1])
+	}
+}

--- a/cmd/evo/main_test.go
+++ b/cmd/evo/main_test.go
@@ -5,9 +5,7 @@ import "testing"
 func TestSplitInstallArgsKeepsPresetFlags(t *testing.T) {
 	installDir, flags, err := splitInstallArgs([]string{
 		"/tmp/site",
-		"--preset=evolution-cms-presets/default",
-		"--preset-ref",
-		"main",
+		"--preset=evolution-cms-presets/default@dev",
 		"--cli",
 	})
 	if err != nil {
@@ -17,7 +15,7 @@ func TestSplitInstallArgsKeepsPresetFlags(t *testing.T) {
 		t.Fatalf("installDir = %q, want /tmp/site", installDir)
 	}
 
-	want := []string{"--preset=evolution-cms-presets/default", "--preset-ref", "main", "--cli"}
+	want := []string{"--preset=evolution-cms-presets/default@dev", "--cli"}
 	if len(flags) != len(want) {
 		t.Fatalf("flags = %#v, want %#v", flags, want)
 	}

--- a/internal/domain/extras.go
+++ b/internal/domain/extras.go
@@ -43,17 +43,19 @@ type ExtrasPackage struct {
 	Icon               string   `json:"icon,omitempty"`
 	DownloadURL        string   `json:"downloadUrl,omitempty"`
 	Dependencies       string   `json:"dependencies,omitempty"`
+	ComposerName       string   `json:"composer_name,omitempty"`
 	Deprecated         bool     `json:"deprecated,omitempty"`
 	Method             string   `json:"method,omitempty"`
 	Required           bool     `json:"required,omitempty"`
 }
 
 type ExtrasSelection struct {
-	ID       string
-	Name     string
-	Source   string
-	Version  string
-	Required bool
+	ID           string
+	Name         string
+	Source       string
+	Version      string
+	ComposerName string
+	Required     bool
 }
 
 type ExtrasItemResult struct {

--- a/internal/domain/extras.go
+++ b/internal/domain/extras.go
@@ -1,5 +1,7 @@
 package domain
 
+import "strings"
+
 type ExtrasStage string
 
 const (
@@ -74,4 +76,168 @@ type ExtrasState struct {
 	CurrentIndex int
 	Total        int
 	Details      []ExtrasItemDetail
+}
+
+const ExtrasFloatingVersionConstraint = "*"
+
+func IsManagedExtrasPackage(pkg ExtrasPackage) bool {
+	source := strings.ToLower(strings.TrimSpace(pkg.Source))
+	mode := strings.ToLower(strings.TrimSpace(pkg.InstallMode))
+	return source == "managed" || mode == "managed-artisan"
+}
+
+func DefaultExtrasInstallVersion(pkg ExtrasPackage) string {
+	if IsManagedExtrasPackage(pkg) {
+		if HasStableExtrasRelease(pkg) {
+			return ExtrasFloatingVersionConstraint
+		}
+		if branch := ComposerDevConstraint(pkg.DefaultBranch); branch != "" {
+			return branch
+		}
+		if branch := branchConstraintFromVersion(pkg.Version); branch != "" {
+			return branch
+		}
+		for _, v := range pkg.Versions {
+			if branch := branchConstraintFromVersion(v); branch != "" {
+				return branch
+			}
+		}
+		return ExtrasFloatingVersionConstraint
+	}
+	return DefaultExtrasVersion(pkg)
+}
+
+func branchConstraintFromVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" || isStableExtrasVersion(version) {
+		return ""
+	}
+	if isBranchLikeVersion(version) || isVersionLikeBranch(version) {
+		return ComposerDevConstraint(version)
+	}
+	return ""
+}
+
+func DefaultExtrasVersion(pkg ExtrasPackage) string {
+	mode := strings.ToLower(strings.TrimSpace(pkg.DefaultInstallMode))
+	version := strings.TrimSpace(pkg.Version)
+	branch := strings.TrimSpace(pkg.DefaultBranch)
+	if mode == "latest-release" && version != "" {
+		return version
+	}
+	if mode == "default-branch" && branch != "" {
+		return branch
+	}
+	if version != "" {
+		return version
+	}
+	if branch != "" {
+		return branch
+	}
+	for _, v := range pkg.Versions {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func NormalizeExtrasInstallVersion(pkg ExtrasPackage, version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return DefaultExtrasInstallVersion(pkg)
+	}
+	if !IsManagedExtrasPackage(pkg) {
+		return version
+	}
+	branch := strings.TrimSpace(pkg.DefaultBranch)
+	if branch != "" && version == branch {
+		return ComposerDevConstraint(version)
+	}
+	if !HasStableExtrasRelease(pkg) && !strings.Contains(version, "/") && isBranchLikeVersion(version) {
+		if dev := ComposerDevConstraint(version); dev != "" {
+			return dev
+		}
+	}
+	return version
+}
+
+func HasStableExtrasRelease(pkg ExtrasPackage) bool {
+	if isStableExtrasVersion(pkg.Version) {
+		return true
+	}
+	for _, v := range pkg.Versions {
+		if isStableExtrasVersion(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func ComposerDevConstraint(branch string) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return ""
+	}
+	lower := strings.ToLower(branch)
+	if strings.HasPrefix(lower, "dev-") || strings.HasSuffix(lower, "-dev") {
+		return branch
+	}
+	if isVersionLikeBranch(branch) {
+		return branch + "-dev"
+	}
+	return "dev-" + branch
+}
+
+func isStableExtrasVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return false
+	}
+	lower := strings.ToLower(version)
+	if strings.HasPrefix(lower, "dev-") || strings.HasSuffix(lower, "-dev") {
+		return false
+	}
+	if isBranchLikeVersion(version) {
+		return false
+	}
+	trimmed := strings.TrimPrefix(lower, "v")
+	if trimmed == "" {
+		return false
+	}
+	for _, r := range trimmed {
+		if (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '+' {
+			continue
+		}
+		return false
+	}
+	return strings.ContainsAny(trimmed, "0123456789")
+}
+
+func isBranchLikeVersion(version string) bool {
+	switch strings.ToLower(strings.TrimSpace(version)) {
+	case "main", "master", "develop", "development", "dev", "trunk", "nightly", "latest":
+		return true
+	default:
+		return false
+	}
+}
+
+func isVersionLikeBranch(branch string) bool {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimPrefix(branch, "v"))
+	if !strings.Contains(lower, ".") {
+		return false
+	}
+	for _, r := range lower {
+		if (r >= '0' && r <= '9') || r == '.' || r == 'x' {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/domain/extras.go
+++ b/internal/domain/extras.go
@@ -45,13 +45,15 @@ type ExtrasPackage struct {
 	Dependencies       string   `json:"dependencies,omitempty"`
 	Deprecated         bool     `json:"deprecated,omitempty"`
 	Method             string   `json:"method,omitempty"`
+	Required           bool     `json:"required,omitempty"`
 }
 
 type ExtrasSelection struct {
-	ID      string
-	Name    string
-	Source  string
-	Version string
+	ID       string
+	Name     string
+	Source   string
+	Version  string
+	Required bool
 }
 
 type ExtrasItemResult struct {

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -86,11 +86,12 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 				Steps: []domain.StepState{
 					{ID: "php", Label: "Step 1: Validate PHP version", Status: domain.StepPending},
 					{ID: "database", Label: "Step 2: Check database connection", Status: domain.StepPending},
-					{ID: "download", Label: "Step 3: Download Evolution CMS", Status: domain.StepPending},
-					{ID: "install", Label: "Step 4: Install Evolution CMS", Status: domain.StepPending},
-					{ID: "presets", Label: "Step 5: Install presets", Status: domain.StepPending},
-					{ID: "finalize", Label: "Step 6: Finalize installation", Status: domain.StepPending},
-					{ID: "extras", Label: "Step 7: Install Extras (optional)", Status: domain.StepPending},
+					{ID: "project_preset", Label: "Step 3: Choose project preset", Status: domain.StepPending},
+					{ID: "download", Label: "Step 4: Download Evolution CMS", Status: domain.StepPending},
+					{ID: "install", Label: "Step 5: Install Evolution CMS", Status: domain.StepPending},
+					{ID: "presets", Label: "Step 6: Apply project preset", Status: domain.StepPending},
+					{ID: "finalize", Label: "Step 7: Finalize installation", Status: domain.StepPending},
+					{ID: "extras", Label: "Step 8: Install Extras (optional)", Status: domain.StepPending},
 				},
 			},
 		})
@@ -972,8 +973,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Source:   "install",
 			Severity: domain.SeverityInfo,
 			Payload: domain.StepStartPayload{
-				Label: "Step 3: Download Evolution CMS",
-				Index: 3,
+				Label: "Step 4: Download Evolution CMS",
+				Index: 4,
 				Total: 8,
 			},
 		})
@@ -1018,12 +1019,48 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 }
 
 func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action) (string, bool) {
+	const stepID = "project_preset"
+	_ = emit(domain.Event{
+		Type:     domain.EventStepStart,
+		StepID:   stepID,
+		Source:   "install",
+		Severity: domain.SeverityInfo,
+		Payload: domain.StepStartPayload{
+			Label: "Step 3: Choose project preset",
+			Index: 3,
+			Total: 8,
+		},
+	})
+
+	done := func(ok bool) {
+		sev := domain.SeverityInfo
+		if !ok {
+			sev = domain.SeverityWarn
+		}
+		_ = emit(domain.Event{
+			Type:     domain.EventStepDone,
+			StepID:   stepID,
+			Source:   "install",
+			Severity: sev,
+			Payload:  domain.StepDonePayload{OK: ok},
+		})
+	}
+
 	preset := strings.TrimSpace(e.opt.Preset)
 	if preset != "" {
+		_ = emit(domain.Event{
+			Type:     domain.EventLog,
+			StepID:   stepID,
+			Source:   "install",
+			Severity: domain.SeverityInfo,
+			Payload: domain.LogPayload{
+				Message: "Using project preset: " + preset + ".",
+			},
+		})
+		done(true)
 		return preset, true
 	}
 
-	const stepID = "presets"
 	_ = emit(domain.Event{
 		Type:     domain.EventLog,
 		StepID:   stepID,
@@ -1057,6 +1094,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 		Selected: selected,
 	})
 	if !ok {
+		done(false)
 		return "", false
 	}
 
@@ -1071,6 +1109,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 				Default: "owner/repo",
 			})
 			if !ok {
+				done(false)
 				return "", false
 			}
 			custom = strings.TrimSpace(custom)
@@ -1095,6 +1134,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 					Message: "Selected custom project preset: " + custom + ".",
 				},
 			})
+			done(true)
 			return custom, true
 		}
 	case projectPresetCoreOnlyID:
@@ -1107,6 +1147,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 				Message: "Selected project preset: Evolution core only.",
 			},
 		})
+		done(true)
 		return "evolution", true
 	default:
 		_ = emit(domain.Event{
@@ -1118,6 +1159,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 				Message: "Selected project preset: " + choice + ".",
 			},
 		})
+		done(true)
 		return choice, true
 	}
 }
@@ -1547,30 +1589,30 @@ func (t *stepTracker) doneStep(stepID string, ok bool) {
 }
 
 func (t *stepTracker) OnLine(line string) {
-	// Step 3 markers.
+	// Step 4 markers.
 	if strings.Contains(line, "Downloading Evolution CMS") || strings.Contains(line, "Finding compatible Evolution CMS version") {
-		t.start("download", "Step 3: Download Evolution CMS", 3)
+		t.start("download", "Step 4: Download Evolution CMS", 4)
 	}
 	if strings.Contains(line, "downloaded and extracted successfully") {
 		t.doneStep("download", true)
-		t.start("install", "Step 4: Install Evolution CMS", 4)
+		t.start("install", "Step 5: Install Evolution CMS", 5)
 	}
 
-	// Step 4 markers.
+	// Step 5 markers.
 	if strings.Contains(line, "Setting up database") {
-		t.start("install", "Step 4: Install Evolution CMS", 4)
+		t.start("install", "Step 5: Install Evolution CMS", 5)
 	}
 	if strings.Contains(line, "All seeders completed successfully") {
 		t.doneStep("install", true)
 	}
-	// Install command now reports migrations and composer install as part of Step 4.
+	// Install command now reports migrations and composer install as part of Step 5.
 	if strings.Contains(line, "Running database migrations") || strings.Contains(line, "Running database seeders") {
-		t.start("install", "Step 4: Install Evolution CMS", 4)
+		t.start("install", "Step 5: Install Evolution CMS", 5)
 	}
 
-	// Step 5 markers.
+	// Step 6 markers.
 	if strings.Contains(line, "Installing project preset") {
-		t.start("presets", "Step 5: Install presets", 5)
+		t.start("presets", "Step 6: Apply project preset", 6)
 	}
 	if strings.Contains(line, "Project preset installed successfully") {
 		t.doneStep("presets", true)
@@ -1578,7 +1620,7 @@ func (t *stepTracker) OnLine(line string) {
 
 	// Finalize marker.
 	if strings.Contains(line, "Finalizing installation") {
-		t.start("finalize", "Step 6: Finalize installation", 6)
+		t.start("finalize", "Step 7: Finalize installation", 7)
 	}
 	if strings.Contains(line, "Installation finalized successfully") {
 		t.doneStep("finalize", true)
@@ -2027,18 +2069,13 @@ func hasProjectPresetCatalogOption(options []domain.QuestionOption) bool {
 }
 
 func appendProjectPresetSpecialOptions(options []domain.QuestionOption) ([]domain.QuestionOption, int) {
-	options = append(options,
-		domain.QuestionOption{ID: projectPresetCustomID, Label: "Custom repository, Git URL, or local path", Enabled: true},
-		domain.QuestionOption{ID: projectPresetCoreOnlyID, Label: "Evolution core only (no project preset)", Enabled: true},
-	)
+	head := []domain.QuestionOption{
+		{ID: projectPresetCoreOnlyID, Label: "No project preset (Evolution core only)", Enabled: true},
+		{ID: projectPresetCustomID, Label: "Custom repository, Git URL, or local path", Enabled: true},
+	}
+	options = append(head, options...)
 
 	selected := 0
-	for i, opt := range options {
-		if opt.ID == projectPresetOrg+"/default" {
-			selected = i
-			break
-		}
-	}
 	return options, selected
 }
 

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/mail"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -275,6 +277,19 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 		}
 
 		workDir := strings.TrimSpace(e.opt.Dir)
+		if workDir == "" {
+			var ok bool
+			workDir, ok = askInput(ctx, emit, actions, "preflight", domain.QuestionState{
+				Active:  true,
+				ID:      "install_dir",
+				Kind:    domain.QuestionInput,
+				Prompt:  "Where should Evolution CMS be installed?",
+				Default: ".",
+			})
+			if !ok {
+				return
+			}
+		}
 		if workDir == "" {
 			workDir = "."
 		}
@@ -945,6 +960,11 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Payload:  domain.StepDonePayload{OK: true},
 		})
 
+		selectedPreset, ok := e.chooseProjectPreset(ctx, emit, actions)
+		if !ok {
+			return
+		}
+
 		// Step 3+: follow InstallCommand pipeline (next).
 		_ = emit(domain.Event{
 			Type:     domain.EventStepStart,
@@ -972,7 +992,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Language:           lang,
 			Force:              e.opt.Force,
 			Branch:             strings.TrimSpace(e.opt.Branch),
-			Preset:             strings.TrimSpace(e.opt.Preset),
+			Preset:             selectedPreset,
 			WorkDir:            workDir,
 			ComposerClearCache: e.opt.ComposerClearCache,
 			ComposerUpdate:     e.opt.ComposerUpdate,
@@ -995,6 +1015,111 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 		e.maybeRunExtras(ctx, emit, actions, workDir)
 		e.cleanupExtrasRuntimeArtifacts(emit, workDir)
 	}()
+}
+
+func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action) (string, bool) {
+	preset := strings.TrimSpace(e.opt.Preset)
+	if preset != "" {
+		return preset, true
+	}
+
+	const stepID = "presets"
+	_ = emit(domain.Event{
+		Type:     domain.EventLog,
+		StepID:   stepID,
+		Source:   "install",
+		Severity: domain.SeverityInfo,
+		Payload: domain.LogPayload{
+			Message: "Fetching project preset catalog...",
+		},
+	})
+
+	options, selected, err := projectPresetQuestionOptions(ctx)
+	if err != nil {
+		_ = emit(domain.Event{
+			Type:     domain.EventWarning,
+			StepID:   stepID,
+			Source:   "install",
+			Severity: domain.SeverityWarn,
+			Payload: domain.LogPayload{
+				Message: "Project preset catalog unavailable; using bundled choices.",
+				Fields:  map[string]string{"error": err.Error()},
+			},
+		})
+	}
+
+	choice, ok := askSelect(ctx, emit, actions, stepID, domain.QuestionState{
+		Active:   true,
+		ID:       "project_preset",
+		Kind:     domain.QuestionSelect,
+		Prompt:   "Which project preset do you want to use?",
+		Options:  options,
+		Selected: selected,
+	})
+	if !ok {
+		return "", false
+	}
+
+	switch choice {
+	case projectPresetCustomID:
+		for {
+			custom, ok := askInput(ctx, emit, actions, stepID, domain.QuestionState{
+				Active:  true,
+				ID:      "project_preset_custom",
+				Kind:    domain.QuestionInput,
+				Prompt:  "Enter preset repository, Git URL, or local path (optional @branch):",
+				Default: "owner/repo",
+			})
+			if !ok {
+				return "", false
+			}
+			custom = strings.TrimSpace(custom)
+			if custom == "" || custom == "owner/repo" {
+				_ = emit(domain.Event{
+					Type:     domain.EventWarning,
+					StepID:   stepID,
+					Source:   "install",
+					Severity: domain.SeverityWarn,
+					Payload: domain.LogPayload{
+						Message: "Custom preset source cannot be empty.",
+					},
+				})
+				continue
+			}
+			_ = emit(domain.Event{
+				Type:     domain.EventLog,
+				StepID:   stepID,
+				Source:   "install",
+				Severity: domain.SeverityInfo,
+				Payload: domain.LogPayload{
+					Message: "Selected custom project preset: " + custom + ".",
+				},
+			})
+			return custom, true
+		}
+	case projectPresetCoreOnlyID:
+		_ = emit(domain.Event{
+			Type:     domain.EventLog,
+			StepID:   stepID,
+			Source:   "install",
+			Severity: domain.SeverityInfo,
+			Payload: domain.LogPayload{
+				Message: "Selected project preset: Evolution core only.",
+			},
+		})
+		return "evolution", true
+	default:
+		_ = emit(domain.Event{
+			Type:     domain.EventLog,
+			StepID:   stepID,
+			Source:   "install",
+			Severity: domain.SeverityInfo,
+			Payload: domain.LogPayload{
+				Message: "Selected project preset: " + choice + ".",
+			},
+		})
+		return choice, true
+	}
 }
 
 func (e *Engine) cleanupExtrasRuntimeArtifacts(emit func(domain.Event) bool, workDir string) {
@@ -1815,6 +1940,119 @@ func defaultPort(dbType string) int {
 
 func defaultSQLiteDatabaseName() string {
 	return "database.sqlite"
+}
+
+const (
+	projectPresetOrg        = "evolution-cms-presets"
+	projectPresetCustomID   = "__custom_project_preset"
+	projectPresetCoreOnlyID = "__evolution_core_only"
+)
+
+func projectPresetQuestionOptions(ctx context.Context) ([]domain.QuestionOption, int, error) {
+	repos, err := github.FetchOrgRepositories(ctx, projectPresetOrg)
+	if err != nil {
+		options, selected := fallbackProjectPresetQuestionOptions()
+		return options, selected, err
+	}
+
+	options, selected := projectPresetOptionsFromRepos(repos)
+	if !hasProjectPresetCatalogOption(options) {
+		return fallbackProjectPresetQuestionOptionsWithError("no preset repositories found")
+	}
+	return options, selected, nil
+}
+
+func fallbackProjectPresetQuestionOptions() ([]domain.QuestionOption, int) {
+	return appendProjectPresetSpecialOptions([]domain.QuestionOption{
+		{ID: projectPresetOrg + "/default", Label: "default", Enabled: true},
+		{ID: projectPresetOrg + "/default-tailwind", Label: "default-tailwind", Enabled: true},
+		{ID: projectPresetOrg + "/default-daisyui", Label: "default-daisyui", Enabled: true},
+	})
+}
+
+func fallbackProjectPresetQuestionOptionsWithError(reason string) ([]domain.QuestionOption, int, error) {
+	options, selected := fallbackProjectPresetQuestionOptions()
+	return options, selected, errors.New(reason)
+}
+
+func projectPresetOptionsFromRepos(repos []github.GitHubRepository) ([]domain.QuestionOption, int) {
+	filtered := make([]github.GitHubRepository, 0, len(repos))
+	for _, repo := range repos {
+		if repo.Archived || strings.TrimSpace(repo.Name) == "" {
+			continue
+		}
+		filtered = append(filtered, repo)
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		pi := projectPresetSortPriority(filtered[i].Name)
+		pj := projectPresetSortPriority(filtered[j].Name)
+		if pi != pj {
+			return pi < pj
+		}
+		return strings.ToLower(filtered[i].Name) < strings.ToLower(filtered[j].Name)
+	})
+
+	options := make([]domain.QuestionOption, 0, len(filtered)+2)
+	seen := map[string]struct{}{}
+	for _, repo := range filtered {
+		name := strings.TrimSpace(repo.Name)
+		id := projectPresetOrg + "/" + name
+		if strings.TrimSpace(repo.FullName) != "" {
+			id = strings.TrimSpace(repo.FullName)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		label := name
+		if desc := strings.TrimSpace(repo.Description); desc != "" {
+			label += " - " + desc
+		}
+		options = append(options, domain.QuestionOption{ID: id, Label: label, Enabled: true})
+	}
+
+	return appendProjectPresetSpecialOptions(options)
+}
+
+func hasProjectPresetCatalogOption(options []domain.QuestionOption) bool {
+	prefix := projectPresetOrg + "/"
+	for _, opt := range options {
+		if strings.HasPrefix(strings.TrimSpace(opt.ID), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendProjectPresetSpecialOptions(options []domain.QuestionOption) ([]domain.QuestionOption, int) {
+	options = append(options,
+		domain.QuestionOption{ID: projectPresetCustomID, Label: "Custom repository, Git URL, or local path", Enabled: true},
+		domain.QuestionOption{ID: projectPresetCoreOnlyID, Label: "Evolution core only (no project preset)", Enabled: true},
+	)
+
+	selected := 0
+	for i, opt := range options {
+		if opt.ID == projectPresetOrg+"/default" {
+			selected = i
+			break
+		}
+	}
+	return options, selected
+}
+
+func projectPresetSortPriority(name string) int {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "default":
+		return 0
+	case "default-tailwind":
+		return 1
+	case "default-daisyui":
+		return 2
+	default:
+		return 100
+	}
 }
 
 func dbDriverLabel(dbType string) string {

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -2021,6 +2021,7 @@ func fallbackProjectPresetQuestionOptions() ([]domain.QuestionOption, int) {
 		{ID: projectPresetOrg + "/default", Label: "default", Enabled: true},
 		{ID: projectPresetOrg + "/default-tailwind", Label: "default-tailwind", Enabled: true},
 		{ID: projectPresetOrg + "/default-daisyui", Label: "default-daisyui", Enabled: true},
+		{ID: projectPresetOrg + "/blog-daisyui", Label: "blog-daisyui", Enabled: true},
 	})
 }
 
@@ -2099,6 +2100,8 @@ func projectPresetSortPriority(name string) int {
 		return 1
 	case "default-daisyui":
 		return 2
+	case "blog-daisyui":
+		return 3
 	default:
 		return 100
 	}

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -31,7 +31,6 @@ type Options struct {
 
 	Branch             string
 	Preset             string
-	PresetRef          string
 	ComposerClearCache bool
 	ComposerUpdate     bool
 
@@ -974,7 +973,6 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Force:              e.opt.Force,
 			Branch:             strings.TrimSpace(e.opt.Branch),
 			Preset:             strings.TrimSpace(e.opt.Preset),
-			PresetRef:          strings.TrimSpace(e.opt.PresetRef),
 			WorkDir:            workDir,
 			ComposerClearCache: e.opt.ComposerClearCache,
 			ComposerUpdate:     e.opt.ComposerUpdate,
@@ -1049,11 +1047,10 @@ type phpNewOptions struct {
 	GithubPat string
 	Extras    []domain.ExtrasSelection
 
-	Force     bool
-	Branch    string
-	Preset    string
-	PresetRef string
-	WorkDir   string
+	Force   bool
+	Branch  string
+	Preset  string
+	WorkDir string
 
 	ComposerClearCache bool
 	ComposerUpdate     bool
@@ -1152,9 +1149,6 @@ func runPHPNewCommand(ctx context.Context, emit func(domain.Event) bool, opt php
 	}
 	if strings.TrimSpace(opt.Preset) != "" {
 		args = append(args, "--preset="+strings.TrimSpace(opt.Preset))
-	}
-	if strings.TrimSpace(opt.PresetRef) != "" {
-		args = append(args, "--preset-ref="+strings.TrimSpace(opt.PresetRef))
 	}
 	if strings.TrimSpace(opt.GithubPat) != "" {
 		args = append(args, "--github-pat="+strings.TrimSpace(opt.GithubPat))

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -30,6 +30,8 @@ type Options struct {
 	SelfVersion string
 
 	Branch             string
+	Preset             string
+	PresetRef          string
 	ComposerClearCache bool
 	ComposerUpdate     bool
 
@@ -971,6 +973,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Language:           lang,
 			Force:              e.opt.Force,
 			Branch:             strings.TrimSpace(e.opt.Branch),
+			Preset:             strings.TrimSpace(e.opt.Preset),
+			PresetRef:          strings.TrimSpace(e.opt.PresetRef),
 			WorkDir:            workDir,
 			ComposerClearCache: e.opt.ComposerClearCache,
 			ComposerUpdate:     e.opt.ComposerUpdate,
@@ -1045,9 +1049,11 @@ type phpNewOptions struct {
 	GithubPat string
 	Extras    []domain.ExtrasSelection
 
-	Force   bool
-	Branch  string
-	WorkDir string
+	Force     bool
+	Branch    string
+	Preset    string
+	PresetRef string
+	WorkDir   string
 
 	ComposerClearCache bool
 	ComposerUpdate     bool
@@ -1143,6 +1149,12 @@ func runPHPNewCommand(ctx context.Context, emit func(domain.Event) bool, opt php
 	}
 	if strings.TrimSpace(opt.Branch) != "" {
 		args = append(args, "--branch="+strings.TrimSpace(opt.Branch))
+	}
+	if strings.TrimSpace(opt.Preset) != "" {
+		args = append(args, "--preset="+strings.TrimSpace(opt.Preset))
+	}
+	if strings.TrimSpace(opt.PresetRef) != "" {
+		args = append(args, "--preset-ref="+strings.TrimSpace(opt.PresetRef))
 	}
 	if strings.TrimSpace(opt.GithubPat) != "" {
 		args = append(args, "--github-pat="+strings.TrimSpace(opt.GithubPat))
@@ -1431,11 +1443,18 @@ func (t *stepTracker) OnLine(line string) {
 	}
 	if strings.Contains(line, "All seeders completed successfully") {
 		t.doneStep("install", true)
-		t.doneStep("presets", true)
 	}
 	// Install command now reports migrations and composer install as part of Step 4.
 	if strings.Contains(line, "Running database migrations") || strings.Contains(line, "Running database seeders") {
 		t.start("install", "Step 4: Install Evolution CMS", 4)
+	}
+
+	// Step 5 markers.
+	if strings.Contains(line, "Installing project preset") {
+		t.start("presets", "Step 5: Install presets", 5)
+	}
+	if strings.Contains(line, "Project preset installed successfully") {
+		t.doneStep("presets", true)
 	}
 
 	// Finalize marker.
@@ -1458,6 +1477,9 @@ func (t *stepTracker) OnLine(line string) {
 	}
 	if strings.Contains(strings.ToLower(line), "failed to update dependencies") {
 		t.doneStep("dependencies", false)
+	}
+	if strings.Contains(strings.ToLower(line), "failed to install project preset") {
+		t.doneStep("presets", false)
 	}
 }
 

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -1013,7 +1013,19 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			return
 		}
 
-		e.maybeRunExtras(ctx, emit, actions, workDir)
+		requiredExtras, warnings := loadPresetRequiredExtras(workDir)
+		for _, msg := range warnings {
+			_ = emit(domain.Event{
+				Type:     domain.EventWarning,
+				StepID:   extrasStepID,
+				Source:   "extras",
+				Severity: domain.SeverityWarn,
+				Payload: domain.LogPayload{
+					Message: msg,
+				},
+			})
+		}
+		e.maybeRunExtras(ctx, emit, actions, workDir, requiredExtras)
 		e.cleanupExtrasRuntimeArtifacts(emit, workDir)
 	}()
 }

--- a/internal/engine/install/engine.go
+++ b/internal/engine/install/engine.go
@@ -89,9 +89,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 					{ID: "project_preset", Label: "Step 3: Choose project preset", Status: domain.StepPending},
 					{ID: "download", Label: "Step 4: Download Evolution CMS", Status: domain.StepPending},
 					{ID: "install", Label: "Step 5: Install Evolution CMS", Status: domain.StepPending},
-					{ID: "presets", Label: "Step 6: Apply project preset", Status: domain.StepPending},
-					{ID: "finalize", Label: "Step 7: Finalize installation", Status: domain.StepPending},
-					{ID: "extras", Label: "Step 8: Install Extras (optional)", Status: domain.StepPending},
+					{ID: "finalize", Label: "Step 6: Finalize installation", Status: domain.StepPending},
+					{ID: "extras", Label: "Step 7: Install Extras", Status: domain.StepPending},
 				},
 			},
 		})
@@ -336,7 +335,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Payload: domain.StepStartPayload{
 				Label: "Step 1: Validate PHP version",
 				Index: 1,
-				Total: 8,
+				Total: 7,
 			},
 		})
 
@@ -408,7 +407,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Payload: domain.StepStartPayload{
 				Label: "Step 2: Check database connection",
 				Index: 2,
-				Total: 8,
+				Total: 7,
 			},
 		})
 
@@ -975,7 +974,7 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, actions <-chan
 			Payload: domain.StepStartPayload{
 				Label: "Step 4: Download Evolution CMS",
 				Index: 4,
-				Total: 8,
+				Total: 7,
 			},
 		})
 
@@ -1040,7 +1039,7 @@ func (e *Engine) chooseProjectPreset(ctx context.Context, emit func(domain.Event
 		Payload: domain.StepStartPayload{
 			Label: "Step 3: Choose project preset",
 			Index: 3,
-			Total: 8,
+			Total: 7,
 		},
 	})
 
@@ -1574,7 +1573,7 @@ func (t *stepTracker) start(stepID, label string, index int) {
 		Payload: domain.StepStartPayload{
 			Label: label,
 			Index: index,
-			Total: 8,
+			Total: 7,
 		},
 	})
 }
@@ -1622,17 +1621,9 @@ func (t *stepTracker) OnLine(line string) {
 		t.start("install", "Step 5: Install Evolution CMS", 5)
 	}
 
-	// Step 6 markers.
-	if strings.Contains(line, "Installing project preset") {
-		t.start("presets", "Step 6: Apply project preset", 6)
-	}
-	if strings.Contains(line, "Project preset installed successfully") {
-		t.doneStep("presets", true)
-	}
-
 	// Finalize marker.
 	if strings.Contains(line, "Finalizing installation") {
-		t.start("finalize", "Step 7: Finalize installation", 7)
+		t.start("finalize", "Step 6: Finalize installation", 6)
 	}
 	if strings.Contains(line, "Installation finalized successfully") {
 		t.doneStep("finalize", true)
@@ -1652,15 +1643,11 @@ func (t *stepTracker) OnLine(line string) {
 		t.doneStep("dependencies", false)
 	}
 	if strings.Contains(strings.ToLower(line), "failed to install project preset") {
-		t.doneStep("presets", false)
+		t.doneStep("install", false)
 	}
 }
 
 func (t *stepTracker) FinishRemaining() {
-	// Presets might not produce logs (it's a no-op by default), but should be considered done if install completed.
-	if t.done["install"] {
-		t.doneStep("presets", true)
-	}
 	// If PHP ran to completion, mark any started but not-done steps as OK (best-effort),
 	// but never override an explicit failure.
 	if t.failed {
@@ -1675,7 +1662,7 @@ func (t *stepTracker) FinishRemaining() {
 
 func (t *stepTracker) FailRemaining() {
 	// Best-effort: mark any not-done steps as failed, so Quest track reflects the abort.
-	for _, id := range []string{"download", "install", "presets", "dependencies", "finalize"} {
+	for _, id := range []string{"download", "install", "dependencies", "finalize"} {
 		if !t.done[id] {
 			t.doneStep(id, false)
 		}

--- a/internal/engine/install/engine_test.go
+++ b/internal/engine/install/engine_test.go
@@ -3,6 +3,8 @@ package install
 import (
 	"strings"
 	"testing"
+
+	"github.com/evolution-cms/installer/internal/services/github"
 )
 
 func TestSanitizeAdminDir(t *testing.T) {
@@ -67,5 +69,61 @@ func TestDbConnectionTestScriptUsesPostgresMaintenanceDb(t *testing.T) {
 
 	if !strings.Contains(dbConnectionTestScript, `"postgres"`) || !strings.Contains(dbConnectionTestScript, `"template1"`) {
 		t.Fatalf("dbConnectionTestScript does not include expected PostgreSQL maintenance database candidates")
+	}
+}
+
+func TestProjectPresetOptionsFromReposPrioritizesDefaultPresets(t *testing.T) {
+	t.Parallel()
+
+	options, selected := projectPresetOptionsFromRepos([]github.GitHubRepository{
+		{Name: "portfolio", FullName: "evolution-cms-presets/portfolio", Description: "Portfolio starter"},
+		{Name: "default-daisyui", FullName: "evolution-cms-presets/default-daisyui"},
+		{Name: "default", FullName: "evolution-cms-presets/default", Description: "Default preset"},
+		{Name: "default-tailwind", FullName: "evolution-cms-presets/default-tailwind"},
+		{Name: "archived", FullName: "evolution-cms-presets/archived", Archived: true},
+	})
+
+	wantIDs := []string{
+		"evolution-cms-presets/default",
+		"evolution-cms-presets/default-tailwind",
+		"evolution-cms-presets/default-daisyui",
+		"evolution-cms-presets/portfolio",
+		projectPresetCustomID,
+		projectPresetCoreOnlyID,
+	}
+	if len(options) != len(wantIDs) {
+		t.Fatalf("got %d options, want %d: %#v", len(options), len(wantIDs), options)
+	}
+	for i, want := range wantIDs {
+		if options[i].ID != want {
+			t.Fatalf("option[%d]=%q, want %q", i, options[i].ID, want)
+		}
+		if !options[i].Enabled {
+			t.Fatalf("option[%d] should be enabled", i)
+		}
+	}
+	if selected != 0 {
+		t.Fatalf("selected=%d, want 0", selected)
+	}
+	if !strings.Contains(options[0].Label, "Default preset") {
+		t.Fatalf("default label does not include description: %q", options[0].Label)
+	}
+}
+
+func TestFallbackProjectPresetOptionsIncludesCustomAndCoreOnly(t *testing.T) {
+	t.Parallel()
+
+	options, selected := fallbackProjectPresetQuestionOptions()
+	if selected != 0 {
+		t.Fatalf("selected=%d, want 0", selected)
+	}
+	if len(options) < 5 {
+		t.Fatalf("expected fallback presets plus special options, got %#v", options)
+	}
+	if options[len(options)-2].ID != projectPresetCustomID {
+		t.Fatalf("expected custom option before core-only, got %#v", options)
+	}
+	if options[len(options)-1].ID != projectPresetCoreOnlyID {
+		t.Fatalf("expected core-only option last, got %#v", options)
 	}
 }

--- a/internal/engine/install/engine_test.go
+++ b/internal/engine/install/engine_test.go
@@ -72,7 +72,7 @@ func TestDbConnectionTestScriptUsesPostgresMaintenanceDb(t *testing.T) {
 	}
 }
 
-func TestProjectPresetOptionsFromReposPrioritizesDefaultPresets(t *testing.T) {
+func TestProjectPresetOptionsFromReposDefaultsToCoreThenCustom(t *testing.T) {
 	t.Parallel()
 
 	options, selected := projectPresetOptionsFromRepos([]github.GitHubRepository{
@@ -84,12 +84,12 @@ func TestProjectPresetOptionsFromReposPrioritizesDefaultPresets(t *testing.T) {
 	})
 
 	wantIDs := []string{
+		projectPresetCoreOnlyID,
+		projectPresetCustomID,
 		"evolution-cms-presets/default",
 		"evolution-cms-presets/default-tailwind",
 		"evolution-cms-presets/default-daisyui",
 		"evolution-cms-presets/portfolio",
-		projectPresetCustomID,
-		projectPresetCoreOnlyID,
 	}
 	if len(options) != len(wantIDs) {
 		t.Fatalf("got %d options, want %d: %#v", len(options), len(wantIDs), options)
@@ -105,8 +105,11 @@ func TestProjectPresetOptionsFromReposPrioritizesDefaultPresets(t *testing.T) {
 	if selected != 0 {
 		t.Fatalf("selected=%d, want 0", selected)
 	}
-	if !strings.Contains(options[0].Label, "Default preset") {
-		t.Fatalf("default label does not include description: %q", options[0].Label)
+	if options[0].ID != projectPresetCoreOnlyID {
+		t.Fatalf("default option should be core-only, got %q", options[0].ID)
+	}
+	if !strings.Contains(options[2].Label, "Default preset") {
+		t.Fatalf("default label does not include description: %q", options[2].Label)
 	}
 }
 
@@ -120,10 +123,10 @@ func TestFallbackProjectPresetOptionsIncludesCustomAndCoreOnly(t *testing.T) {
 	if len(options) < 5 {
 		t.Fatalf("expected fallback presets plus special options, got %#v", options)
 	}
-	if options[len(options)-2].ID != projectPresetCustomID {
-		t.Fatalf("expected custom option before core-only, got %#v", options)
+	if options[0].ID != projectPresetCoreOnlyID {
+		t.Fatalf("expected core-only option first, got %#v", options)
 	}
-	if options[len(options)-1].ID != projectPresetCoreOnlyID {
-		t.Fatalf("expected core-only option last, got %#v", options)
+	if options[1].ID != projectPresetCustomID {
+		t.Fatalf("expected custom option second, got %#v", options)
 	}
 }

--- a/internal/engine/install/engine_test.go
+++ b/internal/engine/install/engine_test.go
@@ -80,6 +80,7 @@ func TestProjectPresetOptionsFromReposDefaultsToCoreThenCustom(t *testing.T) {
 		{Name: "default-daisyui", FullName: "evolution-cms-presets/default-daisyui"},
 		{Name: "default", FullName: "evolution-cms-presets/default", Description: "Default preset"},
 		{Name: "default-tailwind", FullName: "evolution-cms-presets/default-tailwind"},
+		{Name: "blog-daisyui", FullName: "evolution-cms-presets/blog-daisyui"},
 		{Name: "archived", FullName: "evolution-cms-presets/archived", Archived: true},
 	})
 
@@ -89,6 +90,7 @@ func TestProjectPresetOptionsFromReposDefaultsToCoreThenCustom(t *testing.T) {
 		"evolution-cms-presets/default",
 		"evolution-cms-presets/default-tailwind",
 		"evolution-cms-presets/default-daisyui",
+		"evolution-cms-presets/blog-daisyui",
 		"evolution-cms-presets/portfolio",
 	}
 	if len(options) != len(wantIDs) {

--- a/internal/engine/install/extras.go
+++ b/internal/engine/install/extras.go
@@ -74,6 +74,7 @@ func sanitizeExtrasPackages(pkgs []domain.ExtrasPackage) []domain.ExtrasPackage 
 		p.Icon = strings.TrimSpace(p.Icon)
 		p.DownloadURL = strings.TrimSpace(p.DownloadURL)
 		p.Dependencies = strings.TrimSpace(p.Dependencies)
+		p.ComposerName = strings.ToLower(strings.TrimSpace(p.ComposerName))
 		p.Method = strings.TrimSpace(p.Method)
 		if len(p.Versions) > 0 {
 			seen := map[string]struct{}{}

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -112,7 +112,7 @@ func defaultExtrasSelections(pkgs []domain.ExtrasPackage) []domain.ExtrasSelecti
 			ID:      pkg.ID,
 			Name:    pkg.Name,
 			Source:  pkg.Source,
-			Version: strings.TrimSpace(defaultExtrasVersion(pkg)),
+			Version: strings.TrimSpace(defaultExtrasInstallVersion(pkg)),
 		})
 	}
 	return out

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -33,13 +33,15 @@ type legacyStoreStartResponse struct {
 	AllCategory map[string][]legacyStoreCatalogRaw `json:"allcategory"`
 }
 
+type legacyStoreScalar string
+
 type legacyStoreCategory struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
+	ID    legacyStoreScalar `json:"id"`
+	Title string            `json:"title"`
 }
 
 type legacyStoreCatalogRaw struct {
-	ID           string              `json:"id"`
+	ID           legacyStoreScalar   `json:"id"`
 	URL          legacyStoreURLField `json:"url"`
 	Method       string              `json:"method"`
 	Type         string              `json:"type"`
@@ -62,6 +64,27 @@ type legacyStoreVersion struct {
 	File    string `json:"file"`
 	Version string `json:"version"`
 	Date    string `json:"date"`
+}
+
+func (s *legacyStoreScalar) UnmarshalJSON(raw []byte) error {
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return err
+	}
+
+	switch v := value.(type) {
+	case string:
+		*s = legacyStoreScalar(v)
+	case json.Number:
+		*s = legacyStoreScalar(v.String())
+	case nil:
+		*s = ""
+	default:
+		*s = legacyStoreScalar(fmt.Sprint(v))
+	}
+	return nil
 }
 
 func loadAllExtrasCatalogs(ctx context.Context, workDir, token string) ([]domain.ExtrasPackage, []domain.ExtrasSelection, []string, error) {
@@ -315,8 +338,9 @@ func parseLegacyStoreCatalogJSON(raw []byte) ([]domain.ExtrasPackage, error) {
 
 	categories := map[string]string{}
 	for _, cat := range payload.Category {
-		if cat.ID != "" {
-			categories[cat.ID] = strings.TrimSpace(cat.Title)
+		id := strings.TrimSpace(string(cat.ID))
+		if id != "" {
+			categories[id] = strings.TrimSpace(cat.Title)
 		}
 	}
 
@@ -353,7 +377,7 @@ func parseLegacyStoreCatalogJSON(raw []byte) ([]domain.ExtrasPackage, error) {
 			}
 
 			out = append(out, domain.ExtrasPackage{
-				ID:                 "legacy-store:" + strings.TrimSpace(item.ID),
+				ID:                 "legacy-store:" + strings.TrimSpace(string(item.ID)),
 				Name:               name,
 				Version:            version,
 				Versions:           versions,

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -103,6 +103,7 @@ func loadAllExtrasCatalogs(ctx context.Context, workDir, token string) ([]domain
 	if err != nil {
 		warnings = append(warnings, "Managed extras unavailable: "+err.Error())
 	} else {
+		managed = enrichManagedExtrasComposerNames(workDir, managed)
 		pkgs = append(pkgs, managed...)
 	}
 
@@ -160,6 +161,93 @@ func extrasSourcePriority(source string) int {
 	default:
 		return 10
 	}
+}
+
+type extrasCatalogComposerPackage struct {
+	Name         string `json:"name"`
+	FullName     string `json:"full_name"`
+	ComposerName string `json:"composer_name"`
+}
+
+type extrasCatalogComposerCache struct {
+	Packages []extrasCatalogComposerPackage `json:"packages"`
+}
+
+func enrichManagedExtrasComposerNames(workDir string, pkgs []domain.ExtrasPackage) []domain.ExtrasPackage {
+	if len(pkgs) == 0 {
+		return pkgs
+	}
+
+	composerNames := loadExtrasComposerNameMap(workDir)
+	for i := range pkgs {
+		if strings.TrimSpace(pkgs[i].ComposerName) != "" {
+			pkgs[i].ComposerName = normalizeComposerPackageName(pkgs[i].ComposerName)
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(pkgs[i].Name))
+		if composerName := composerNames[key]; composerName != "" {
+			pkgs[i].ComposerName = composerName
+			continue
+		}
+		pkgs[i].ComposerName = inferManagedExtrasComposerName(pkgs[i].Name)
+	}
+	return pkgs
+}
+
+func loadExtrasComposerNameMap(workDir string) map[string]string {
+	path := filepath.Join(absDir(workDir), "core", "custom", "cache", "extras.catalog.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var catalog extrasCatalogComposerCache
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		return nil
+	}
+
+	out := map[string]string{}
+	for _, pkg := range catalog.Packages {
+		name := strings.ToLower(strings.TrimSpace(pkg.Name))
+		if name == "" {
+			continue
+		}
+		composerName := normalizeComposerPackageName(pkg.ComposerName)
+		if composerName == "" {
+			composerName = normalizeComposerPackageName(pkg.FullName)
+		}
+		if composerName == "" {
+			continue
+		}
+		out[name] = composerName
+	}
+	return out
+}
+
+func inferManagedExtrasComposerName(name string) string {
+	name = strings.TrimSpace(name)
+	if len(name) < 2 {
+		return ""
+	}
+	packageName := strings.ToLower(name)
+	switch name[0] {
+	case 'e', 'E':
+		return "evolution-cms/" + packageName
+	case 's', 'S':
+		return "seiger/" + packageName
+	case 'd', 'D':
+		return "dmi3yy/" + packageName
+	default:
+		return ""
+	}
+}
+
+func normalizeComposerPackageName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if !strings.Contains(name, "/") {
+		return ""
+	}
+	return name
 }
 
 func defaultExtrasSelections(pkgs []domain.ExtrasPackage) []domain.ExtrasSelection {

--- a/internal/engine/install/extras_catalog.go
+++ b/internal/engine/install/extras_catalog.go
@@ -120,9 +120,46 @@ func loadAllExtrasCatalogs(ctx context.Context, workDir, token string) ([]domain
 		pkgs = append(pkgs, legacy...)
 	}
 
+	pkgs = dedupeExtrasPackages(pkgs)
 	sortExtrasPackages(pkgs)
 	defaults := defaultExtrasSelections(pkgs)
 	return pkgs, defaults, warnings, nil
+}
+
+func dedupeExtrasPackages(pkgs []domain.ExtrasPackage) []domain.ExtrasPackage {
+	if len(pkgs) == 0 {
+		return nil
+	}
+	out := make([]domain.ExtrasPackage, 0, len(pkgs))
+	seen := map[string]int{}
+	for _, pkg := range pkgs {
+		key := strings.ToLower(strings.TrimSpace(pkg.Name))
+		if key == "" {
+			continue
+		}
+		if idx, ok := seen[key]; ok {
+			if extrasSourcePriority(pkg.Source) < extrasSourcePriority(out[idx].Source) {
+				out[idx] = pkg
+			}
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, pkg)
+	}
+	return out
+}
+
+func extrasSourcePriority(source string) int {
+	switch strings.TrimSpace(source) {
+	case "bundled-inline":
+		return 0
+	case "managed":
+		return 1
+	case "legacy-store":
+		return 2
+	default:
+		return 10
+	}
 }
 
 func defaultExtrasSelections(pkgs []domain.ExtrasPackage) []domain.ExtrasSelection {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	extrasPromptID                  = "extras_prompt"
 	extrasSelectID                  = "extras_select"
 	extrasStepID                    = "extras"
 	extrasSkipValue                 = "skip"
@@ -36,7 +35,7 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			Source:   "extras",
 			Severity: domain.SeverityInfo,
 			Payload: domain.StepStartPayload{
-				Label: "Step 7: Install Extras (optional)",
+				Label: "Step 8: Install Extras (optional)",
 				Index: 8,
 				Total: 8,
 			},
@@ -87,26 +86,6 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 	}
 
 	preselected := e.opt.Extras
-	if len(preselected) == 0 {
-		choice, ok := askSelect(ctx, emit, actions, extrasStepID, extrasPromptQuestion())
-		if !ok {
-			return
-		}
-		if strings.ToLower(strings.TrimSpace(choice)) != "yes" {
-			_ = emit(domain.Event{
-				Type:     domain.EventLog,
-				StepID:   extrasStepID,
-				Source:   "extras",
-				Severity: domain.SeverityInfo,
-				Payload: domain.LogPayload{
-					Message: "Skipping extras installation.",
-				},
-			})
-			emitExtrasSkippedSummary(emit)
-			return
-		}
-	}
-
 	_ = emit(domain.Event{
 		Type:     domain.EventLog,
 		StepID:   extrasStepID,
@@ -434,20 +413,6 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			stepOK = false
 			break
 		}
-	}
-}
-
-func extrasPromptQuestion() domain.QuestionState {
-	return domain.QuestionState{
-		Active: true,
-		ID:     extrasPromptID,
-		Kind:   domain.QuestionSelect,
-		Prompt: "Do you want to install additional packages (Extras) now?",
-		Options: []domain.QuestionOption{
-			{ID: "yes", Label: "Yes", Enabled: true},
-			{ID: "no", Label: "No", Enabled: true},
-		},
-		Selected: 0,
 	}
 }
 

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -16,7 +16,7 @@ const (
 	extrasInstallValue = "install"
 )
 
-func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action, workDir string) {
+func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action, workDir string, requiredExtras []domain.ExtrasSelection) {
 	if actions == nil {
 		return
 	}
@@ -85,6 +85,21 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 	}
 
 	preselected := e.opt.Extras
+	if len(requiredExtras) > 0 {
+		labels := make([]string, 0, len(requiredExtras))
+		for _, sel := range requiredExtras {
+			labels = append(labels, formatExtrasSelectionLabel(sel))
+		}
+		_ = emit(domain.Event{
+			Type:     domain.EventLog,
+			StepID:   extrasStepID,
+			Source:   "extras",
+			Severity: domain.SeverityInfo,
+			Payload: domain.LogPayload{
+				Message: "Preset requires extras: " + strings.Join(labels, ", "),
+			},
+		})
+	}
 	_ = emit(domain.Event{
 		Type:     domain.EventLog,
 		StepID:   extrasStepID,
@@ -97,6 +112,18 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 
 	token := strings.TrimSpace(e.opt.GithubPat)
 	pkgs, defaults, warnings, err := loadAllExtrasCatalogs(ctx, workDir, token)
+	normalizedRequired := requiredExtras
+	if len(pkgs) > 0 && len(requiredExtras) > 0 {
+		normalizedRequired = normalizeExtrasSelections(pkgs, requiredExtras)
+		if len(normalizedRequired) == 0 {
+			normalizedRequired = requiredExtras
+		}
+	}
+	pkgs = markRequiredExtrasPackages(pkgs, normalizedRequired)
+	defaults = mergeRequiredExtras(defaults, normalizedRequired)
+	if len(pkgs) > 0 {
+		defaults = normalizeExtrasSelections(pkgs, defaults)
+	}
 	for _, msg := range warnings {
 		_ = emit(domain.Event{
 			Type:     domain.EventWarning,
@@ -123,7 +150,7 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			},
 		})
 		stepOK = false
-		if len(preselected) == 0 {
+		if len(preselected) == 0 && len(requiredExtras) == 0 {
 			return
 		}
 	}
@@ -145,13 +172,41 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 
 	var selections []domain.ExtrasSelection
 	if len(preselected) > 0 {
-		selections = preselected
+		selections = mergeRequiredExtras(preselected, normalizedRequired)
 	} else {
 		action, chosen, ok := waitExtrasDecision(ctx, actions)
 		if !ok {
 			return
 		}
 		if action != extrasInstallValue || len(chosen) == 0 {
+			if len(normalizedRequired) > 0 {
+				selections = mergeRequiredExtras(nil, normalizedRequired)
+			} else {
+				_ = emit(domain.Event{
+					Type:     domain.EventExtras,
+					StepID:   extrasStepID,
+					Source:   "extras",
+					Severity: domain.SeverityInfo,
+					Payload: domain.ExtrasState{
+						Active: false,
+					},
+				})
+				_ = emit(domain.Event{
+					Type:     domain.EventLog,
+					StepID:   extrasStepID,
+					Source:   "extras",
+					Severity: domain.SeverityInfo,
+					Payload: domain.LogPayload{
+						Message: "Extras installation skipped.",
+					},
+				})
+				emitExtrasSkippedSummary(emit)
+				return
+			}
+		} else {
+			selections = mergeRequiredExtras(chosen, normalizedRequired)
+		}
+		if len(selections) == 0 {
 			_ = emit(domain.Event{
 				Type:     domain.EventExtras,
 				StepID:   extrasStepID,
@@ -173,7 +228,6 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			emitExtrasSkippedSummary(emit)
 			return
 		}
-		selections = chosen
 	}
 
 	if len(pkgs) > 0 {
@@ -516,13 +570,79 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		}
 		seen[id] = len(out)
 		out = append(out, domain.ExtrasSelection{
-			ID:      id,
-			Name:    pkg.Name,
-			Source:  pkg.Source,
-			Version: version,
+			ID:       id,
+			Name:     pkg.Name,
+			Source:   pkg.Source,
+			Version:  version,
+			Required: sel.Required || pkg.Required,
 		})
 	}
 	return out
+}
+
+func mergeRequiredExtras(selections []domain.ExtrasSelection, required []domain.ExtrasSelection) []domain.ExtrasSelection {
+	if len(selections) == 0 && len(required) == 0 {
+		return nil
+	}
+
+	out := make([]domain.ExtrasSelection, 0, len(selections)+len(required))
+	seen := map[string]int{}
+	add := func(sel domain.ExtrasSelection, forceRequired bool) {
+		key := extrasSelectionIdentity(sel)
+		if key == "" {
+			return
+		}
+		if forceRequired {
+			sel.Required = true
+		}
+		if idx, ok := seen[key]; ok {
+			if out[idx].Version == "" && strings.TrimSpace(sel.Version) != "" {
+				out[idx].Version = strings.TrimSpace(sel.Version)
+			}
+			out[idx].Required = out[idx].Required || sel.Required
+			return
+		}
+		seen[key] = len(out)
+		out = append(out, sel)
+	}
+
+	for _, sel := range selections {
+		add(sel, false)
+	}
+	for _, sel := range required {
+		add(sel, true)
+	}
+	return out
+}
+
+func markRequiredExtrasPackages(pkgs []domain.ExtrasPackage, required []domain.ExtrasSelection) []domain.ExtrasPackage {
+	if len(pkgs) == 0 || len(required) == 0 {
+		return pkgs
+	}
+	requiredKeys := map[string]struct{}{}
+	for _, sel := range required {
+		if key := strings.ToLower(strings.TrimSpace(sel.ID)); key != "" {
+			requiredKeys[key] = struct{}{}
+		}
+		if key := strings.ToLower(strings.TrimSpace(sel.Name)); key != "" {
+			requiredKeys[key] = struct{}{}
+		}
+	}
+	for i := range pkgs {
+		_, idRequired := requiredKeys[strings.ToLower(strings.TrimSpace(pkgs[i].ID))]
+		_, nameRequired := requiredKeys[strings.ToLower(strings.TrimSpace(pkgs[i].Name))]
+		if idRequired || nameRequired {
+			pkgs[i].Required = true
+		}
+	}
+	return pkgs
+}
+
+func extrasSelectionIdentity(sel domain.ExtrasSelection) string {
+	if id := strings.ToLower(strings.TrimSpace(sel.ID)); id != "" {
+		return id
+	}
+	return strings.ToLower(strings.TrimSpace(sel.Name))
 }
 
 func defaultExtrasInstallVersion(pkg domain.ExtrasPackage) string {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	extrasPromptID     = "extras_prompt"
-	extrasSelectID     = "extras_select"
-	extrasStepID       = "extras"
-	extrasSkipValue    = "skip"
-	extrasInstallValue = "install"
+	extrasPromptID                  = "extras_prompt"
+	extrasSelectID                  = "extras_select"
+	extrasStepID                    = "extras"
+	extrasSkipValue                 = "skip"
+	extrasInstallValue              = "install"
+	extrasFloatingVersionConstraint = "*"
 )
 
 func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action, workDir string) {
@@ -539,7 +540,7 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		}
 		version := strings.TrimSpace(sel.Version)
 		if version == "" {
-			version = strings.TrimSpace(defaultExtrasVersion(pkg))
+			version = strings.TrimSpace(defaultExtrasInstallVersion(pkg))
 		}
 		if idx, ok := seen[id]; ok {
 			if out[idx].Version == "" && version != "" {
@@ -556,6 +557,19 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		})
 	}
 	return out
+}
+
+func defaultExtrasInstallVersion(pkg domain.ExtrasPackage) string {
+	if isManagedExtrasPackage(pkg) {
+		return extrasFloatingVersionConstraint
+	}
+	return defaultExtrasVersion(pkg)
+}
+
+func isManagedExtrasPackage(pkg domain.ExtrasPackage) bool {
+	source := strings.ToLower(strings.TrimSpace(pkg.Source))
+	mode := strings.ToLower(strings.TrimSpace(pkg.InstallMode))
+	return source == "managed" || mode == "managed-artisan"
 }
 
 func formatExtrasSelectionLabel(sel domain.ExtrasSelection) string {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -524,6 +524,7 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 	allowed := map[string]struct{}{}
 	pkgByID := map[string]domain.ExtrasPackage{}
 	pkgByName := map[string]domain.ExtrasPackage{}
+	pkgByComposerName := map[string]domain.ExtrasPackage{}
 	for _, p := range pkgs {
 		if p.ID != "" {
 			allowed[p.ID] = struct{}{}
@@ -531,6 +532,9 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		}
 		if p.Name != "" {
 			pkgByName[strings.ToLower(p.Name)] = p
+		}
+		if composerName := normalizeComposerPackageName(p.ComposerName); composerName != "" {
+			pkgByComposerName[composerName] = p
 		}
 	}
 	out := make([]domain.ExtrasSelection, 0, len(selections))
@@ -545,9 +549,18 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		if !ok {
 			name := strings.ToLower(strings.TrimSpace(sel.Name))
 			if name == "" {
-				continue
+				name = normalizeComposerPackageName(sel.ComposerName)
 			}
 			pkg, ok = pkgByName[name]
+		}
+		if !ok {
+			composerName := normalizeComposerPackageName(sel.ComposerName)
+			if composerName == "" {
+				composerName = normalizeComposerPackageName(sel.Name)
+			}
+			if composerName != "" {
+				pkg, ok = pkgByComposerName[composerName]
+			}
 		}
 		if !ok {
 			continue
@@ -570,11 +583,12 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		}
 		seen[id] = len(out)
 		out = append(out, domain.ExtrasSelection{
-			ID:       id,
-			Name:     pkg.Name,
-			Source:   pkg.Source,
-			Version:  version,
-			Required: sel.Required || pkg.Required,
+			ID:           id,
+			Name:         pkg.Name,
+			Source:       pkg.Source,
+			Version:      version,
+			ComposerName: normalizeComposerPackageName(pkg.ComposerName),
+			Required:     sel.Required || pkg.Required,
 		})
 	}
 	return out
@@ -595,6 +609,7 @@ func mergeRequiredExtras(selections []domain.ExtrasSelection, required []domain.
 		if forceRequired {
 			sel.Required = true
 		}
+		sel.ComposerName = normalizeComposerPackageName(sel.ComposerName)
 		if idx, ok := seen[key]; ok {
 			if out[idx].Version == "" && strings.TrimSpace(sel.Version) != "" {
 				out[idx].Version = strings.TrimSpace(sel.Version)
@@ -627,11 +642,15 @@ func markRequiredExtrasPackages(pkgs []domain.ExtrasPackage, required []domain.E
 		if key := strings.ToLower(strings.TrimSpace(sel.Name)); key != "" {
 			requiredKeys[key] = struct{}{}
 		}
+		if key := normalizeComposerPackageName(sel.ComposerName); key != "" {
+			requiredKeys[key] = struct{}{}
+		}
 	}
 	for i := range pkgs {
 		_, idRequired := requiredKeys[strings.ToLower(strings.TrimSpace(pkgs[i].ID))]
 		_, nameRequired := requiredKeys[strings.ToLower(strings.TrimSpace(pkgs[i].Name))]
-		if idRequired || nameRequired {
+		_, composerRequired := requiredKeys[normalizeComposerPackageName(pkgs[i].ComposerName)]
+		if idRequired || nameRequired || composerRequired {
 			pkgs[i].Required = true
 		}
 	}
@@ -641,6 +660,9 @@ func markRequiredExtrasPackages(pkgs []domain.ExtrasPackage, required []domain.E
 func extrasSelectionIdentity(sel domain.ExtrasSelection) string {
 	if id := strings.ToLower(strings.TrimSpace(sel.ID)); id != "" {
 		return id
+	}
+	if composerName := normalizeComposerPackageName(sel.ComposerName); composerName != "" {
+		return "composer:" + composerName
 	}
 	return strings.ToLower(strings.TrimSpace(sel.Name))
 }
@@ -655,6 +677,9 @@ func isManagedExtrasPackage(pkg domain.ExtrasPackage) bool {
 
 func formatExtrasSelectionLabel(sel domain.ExtrasSelection) string {
 	name := strings.TrimSpace(sel.Name)
+	if name == "" {
+		name = strings.TrimSpace(sel.ComposerName)
+	}
 	if name == "" {
 		name = strings.TrimSpace(sel.ID)
 	}

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -10,11 +10,10 @@ import (
 )
 
 const (
-	extrasSelectID                  = "extras_select"
-	extrasStepID                    = "extras"
-	extrasSkipValue                 = "skip"
-	extrasInstallValue              = "install"
-	extrasFloatingVersionConstraint = "*"
+	extrasSelectID     = "extras_select"
+	extrasStepID       = "extras"
+	extrasSkipValue    = "skip"
+	extrasInstallValue = "install"
 )
 
 func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) bool, actions <-chan domain.Action, workDir string) {
@@ -506,6 +505,8 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 		version := strings.TrimSpace(sel.Version)
 		if version == "" {
 			version = strings.TrimSpace(defaultExtrasInstallVersion(pkg))
+		} else {
+			version = strings.TrimSpace(domain.NormalizeExtrasInstallVersion(pkg, version))
 		}
 		if idx, ok := seen[id]; ok {
 			if out[idx].Version == "" && version != "" {
@@ -525,16 +526,11 @@ func normalizeExtrasSelections(pkgs []domain.ExtrasPackage, selections []domain.
 }
 
 func defaultExtrasInstallVersion(pkg domain.ExtrasPackage) string {
-	if isManagedExtrasPackage(pkg) {
-		return extrasFloatingVersionConstraint
-	}
-	return defaultExtrasVersion(pkg)
+	return domain.DefaultExtrasInstallVersion(pkg)
 }
 
 func isManagedExtrasPackage(pkg domain.ExtrasPackage) bool {
-	source := strings.ToLower(strings.TrimSpace(pkg.Source))
-	mode := strings.ToLower(strings.TrimSpace(pkg.InstallMode))
-	return source == "managed" || mode == "managed-artisan"
+	return domain.IsManagedExtrasPackage(pkg)
 }
 
 func formatExtrasSelectionLabel(sel domain.ExtrasSelection) string {
@@ -597,28 +593,7 @@ func runExtrasSelection(ctx context.Context, coreDir string, token string, pkgBy
 }
 
 func defaultExtrasVersion(pkg domain.ExtrasPackage) string {
-	mode := strings.ToLower(strings.TrimSpace(pkg.DefaultInstallMode))
-	version := strings.TrimSpace(pkg.Version)
-	branch := strings.TrimSpace(pkg.DefaultBranch)
-	if mode == "latest-release" && version != "" {
-		return version
-	}
-	if mode == "default-branch" && branch != "" {
-		return branch
-	}
-	if version != "" {
-		return version
-	}
-	if branch != "" {
-		return branch
-	}
-	for _, v := range pkg.Versions {
-		v = strings.TrimSpace(v)
-		if v != "" {
-			return v
-		}
-	}
-	return ""
+	return domain.DefaultExtrasVersion(pkg)
 }
 
 func extrasFailFast() bool {

--- a/internal/engine/install/extras_flow.go
+++ b/internal/engine/install/extras_flow.go
@@ -34,9 +34,9 @@ func (e *Engine) maybeRunExtras(ctx context.Context, emit func(domain.Event) boo
 			Source:   "extras",
 			Severity: domain.SeverityInfo,
 			Payload: domain.StepStartPayload{
-				Label: "Step 8: Install Extras (optional)",
-				Index: 8,
-				Total: 8,
+				Label: "Step 7: Install Extras",
+				Index: 7,
+				Total: 7,
 			},
 		})
 	}

--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -100,13 +100,29 @@ function helper_parse_csv(string $value): array
     }));
 }
 
+function helper_description(array $item): string
+{
+    $description = trim((string) ($item['description'] ?? ''));
+    $version = trim((string) ($item['version'] ?? ''));
+
+    if ($version === '') {
+        return $description;
+    }
+
+    if (preg_match('/<strong>\s*' . preg_quote($version, '/') . '\s*<\/strong>/i', $description) === 1) {
+        return $description;
+    }
+
+    return '<strong>' . $version . '</strong>' . ($description !== '' ? ' ' . $description : '');
+}
+
 function helper_install_template(array $item, string $path): void
 {
     $name = trim((string) ($item['name'] ?? ''));
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
     $locked = !empty($item['locked']) ? 1 : 0;
     $code = helper_chunk_code($path);
@@ -139,7 +155,7 @@ function helper_install_tv(array $item, string $path): void
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $caption = trim((string) ($item['caption'] ?? ''));
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
     $locked = !empty($item['locked']) ? 1 : 0;
@@ -188,7 +204,7 @@ function helper_install_plugin(array $item, string $path): void
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $properties = trim((string) ($item['properties'] ?? ''));
     $guid = trim((string) ($item['guid'] ?? ''));
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
@@ -302,7 +318,7 @@ function helper_install_module(array $item, string $path): void
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $properties = trim((string) ($item['properties'] ?? ''));
     $guid = trim((string) ($item['guid'] ?? ''));
     $shared = (int) ($item['shareParams'] ?? 0);
@@ -341,7 +357,7 @@ function helper_install_snippet(array $item, string $path): void
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $properties = trim((string) ($item['properties'] ?? ''));
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
     $code = helper_snippet_code($path);
@@ -373,7 +389,7 @@ function helper_install_chunk(array $item, string $path): void
     if ($name === '') {
         return;
     }
-    $desc = trim((string) ($item['description'] ?? ''));
+    $desc = helper_description($item);
     $category = getCreateDbCategory(trim((string) ($item['category'] ?? '')));
     $overwrite = strtolower(trim((string) ($item['overwrite'] ?? 'true')));
     $code = helper_chunk_code($path);

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -137,8 +137,55 @@ func TestNormalizeExtrasSelectionsUsesIDsAndDefaults(t *testing.T) {
 	if selections[0].Source != "bundled-inline" {
 		t.Fatalf("unexpected source for bundled selection: %q", selections[0].Source)
 	}
-	if selections[1].Version != "1.2.3" {
-		t.Fatalf("expected managed default version, got %q", selections[1].Version)
+	if selections[1].Version != "*" {
+		t.Fatalf("expected managed default version constraint, got %q", selections[1].Version)
+	}
+}
+
+func TestNormalizeExtrasSelectionsKeepsExplicitManagedVersion(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:sSeo",
+			Name:               "sSeo",
+			Source:             "managed",
+			Version:            "1.2.3",
+			DefaultInstallMode: "latest-release",
+		},
+	}
+
+	selections := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{Name: "sSeo", Version: "v1.2.2"},
+	})
+	if len(selections) != 1 {
+		t.Fatalf("expected 1 selection, got %d", len(selections))
+	}
+	if selections[0].Version != "v1.2.2" {
+		t.Fatalf("expected explicit managed version to be kept, got %q", selections[0].Version)
+	}
+}
+
+func TestDefaultExtrasSelectionsUseFloatingManagedConstraint(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:sSeo",
+			Name:               "sSeo",
+			Source:             "managed",
+			Version:            "1.2.3",
+			DefaultInstallMode: "latest-release",
+			Preselected:        true,
+		},
+	}
+
+	selections := defaultExtrasSelections(pkgs)
+	if len(selections) != 1 {
+		t.Fatalf("expected 1 default selection, got %d", len(selections))
+	}
+	if selections[0].Version != "*" {
+		t.Fatalf("expected default managed selection to use wildcard, got %q", selections[0].Version)
 	}
 }
 

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -189,6 +189,53 @@ func TestDefaultExtrasSelectionsUseFloatingManagedConstraint(t *testing.T) {
 	}
 }
 
+func TestDefaultExtrasSelectionsUseDevBranchForDevOnlyManagedPackage(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:ePasskeys",
+			Name:               "ePasskeys",
+			Source:             "managed",
+			DefaultInstallMode: "default-branch",
+			DefaultBranch:      "main",
+			Preselected:        true,
+		},
+	}
+
+	selections := defaultExtrasSelections(pkgs)
+	if len(selections) != 1 {
+		t.Fatalf("expected 1 default selection, got %d", len(selections))
+	}
+	if selections[0].Version != "dev-main" {
+		t.Fatalf("expected dev-only managed selection to use dev-main, got %q", selections[0].Version)
+	}
+}
+
+func TestNormalizeExtrasSelectionsConvertsExplicitManagedDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:ePasskeys",
+			Name:               "ePasskeys",
+			Source:             "managed",
+			DefaultInstallMode: "default-branch",
+			DefaultBranch:      "main",
+		},
+	}
+
+	selections := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{Name: "ePasskeys", Version: "main"},
+	})
+	if len(selections) != 1 {
+		t.Fatalf("expected 1 selection, got %d", len(selections))
+	}
+	if selections[0].Version != "dev-main" {
+		t.Fatalf("expected explicit managed branch to normalize to dev-main, got %q", selections[0].Version)
+	}
+}
+
 func TestDedupeExtrasPackagesPrefersManagedOverLegacyDuplicate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -236,6 +236,59 @@ func TestNormalizeExtrasSelectionsConvertsExplicitManagedDefaultBranch(t *testin
 	}
 }
 
+func TestParsePresetRequiredExtrasSupportsStringsAndObjects(t *testing.T) {
+	t.Parallel()
+
+	selections, err := parsePresetRequiredExtras([]byte(`{
+		"requiredExtras": ["eTinyMCE", {"name": "sSeo", "version": "*"}],
+		"extras": {"required": ["ePasskeys@main"]}
+	}`))
+	if err != nil {
+		t.Fatalf("parsePresetRequiredExtras returned error: %v", err)
+	}
+	if len(selections) != 3 {
+		t.Fatalf("expected 3 required extras, got %#v", selections)
+	}
+	if selections[0].Name != "eTinyMCE" || !selections[0].Required {
+		t.Fatalf("unexpected first selection: %#v", selections[0])
+	}
+	if selections[1].Name != "sSeo" || selections[1].Version != "*" || !selections[1].Required {
+		t.Fatalf("unexpected second selection: %#v", selections[1])
+	}
+	if selections[2].Name != "ePasskeys" || selections[2].Version != "main" || !selections[2].Required {
+		t.Fatalf("unexpected third selection: %#v", selections[2])
+	}
+}
+
+func TestRequiredExtrasStaySelectedWhenUserSkips(t *testing.T) {
+	t.Parallel()
+
+	required := []domain.ExtrasSelection{{Name: "sSeo", Required: true}}
+	selections := mergeRequiredExtras(nil, required)
+	if len(selections) != 1 {
+		t.Fatalf("expected required selection, got %#v", selections)
+	}
+	if selections[0].Name != "sSeo" || !selections[0].Required {
+		t.Fatalf("unexpected required selection: %#v", selections[0])
+	}
+}
+
+func TestMarkRequiredExtrasPackagesMatchesByNameAfterNormalize(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{ID: "managed:sSeo", Name: "sSeo", Source: "managed"},
+		{ID: "managed:sTask", Name: "sTask", Source: "managed"},
+	}
+	got := markRequiredExtrasPackages(pkgs, []domain.ExtrasSelection{{Name: "sSeo", Required: true}})
+	if !got[0].Required {
+		t.Fatalf("expected sSeo package to be marked required: %#v", got[0])
+	}
+	if got[1].Required {
+		t.Fatalf("did not expect sTask package to be required: %#v", got[1])
+	}
+}
+
 func TestDedupeExtrasPackagesPrefersManagedOverLegacyDuplicate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -236,6 +236,123 @@ func TestNormalizeExtrasSelectionsConvertsExplicitManagedDefaultBranch(t *testin
 	}
 }
 
+func TestNormalizeExtrasSelectionsMatchesComposerPackageName(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:eTinyMCE",
+			Name:               "eTinyMCE",
+			Source:             "managed",
+			InstallMode:        "managed-artisan",
+			DefaultInstallMode: "latest-release",
+			Version:            "8.3.2",
+			ComposerName:       "evolution-cms/etinymce",
+		},
+	}
+
+	selections := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{
+			Name:         "evolution-cms/etinymce",
+			Source:       "composer-require",
+			Version:      "*",
+			ComposerName: "evolution-cms/etinymce",
+			Required:     true,
+		},
+	})
+	if len(selections) != 1 {
+		t.Fatalf("expected composer selection to resolve, got %#v", selections)
+	}
+	if selections[0].ID != "managed:eTinyMCE" || selections[0].Name != "eTinyMCE" || selections[0].Version != "*" || !selections[0].Required {
+		t.Fatalf("unexpected composer selection: %#v", selections[0])
+	}
+}
+
+func TestPresetRequiredExtrasMergeWithUserSelectedExtras(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:eTinyMCE",
+			Name:               "eTinyMCE",
+			Source:             "managed",
+			InstallMode:        "managed-artisan",
+			DefaultInstallMode: "latest-release",
+			Version:            "8.3.2",
+			ComposerName:       "evolution-cms/etinymce",
+		},
+		{
+			ID:                 "managed:ePasskeys",
+			Name:               "ePasskeys",
+			Source:             "managed",
+			InstallMode:        "managed-artisan",
+			DefaultInstallMode: "default-branch",
+			DefaultBranch:      "main",
+			ComposerName:       "evolution-cms/epasskeys",
+		},
+	}
+
+	required := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{
+			Name:         "evolution-cms/etinymce",
+			Source:       "composer-require",
+			Version:      "*",
+			ComposerName: "evolution-cms/etinymce",
+			Required:     true,
+		},
+	})
+	selected := mergeRequiredExtras([]domain.ExtrasSelection{{Name: "ePasskeys"}}, required)
+	selected = normalizeExtrasSelections(pkgs, selected)
+
+	if len(selected) != 2 {
+		t.Fatalf("expected required and user-selected extras, got %#v", selected)
+	}
+	if selected[0].Name != "ePasskeys" || selected[0].Required {
+		t.Fatalf("expected user-selected extra to stay optional, got %#v", selected[0])
+	}
+	if selected[1].Name != "eTinyMCE" || !selected[1].Required {
+		t.Fatalf("expected composer-required extra to stay required, got %#v", selected[1])
+	}
+	if selected[1].Version != "*" {
+		t.Fatalf("expected required composer version to be kept, got %q", selected[1].Version)
+	}
+}
+
+func TestPresetRequiredExtrasDedupeWhenUserAlsoSelectsRequiredExtra(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []domain.ExtrasPackage{
+		{
+			ID:                 "managed:eTinyMCE",
+			Name:               "eTinyMCE",
+			Source:             "managed",
+			InstallMode:        "managed-artisan",
+			DefaultInstallMode: "latest-release",
+			Version:            "8.3.2",
+			ComposerName:       "evolution-cms/etinymce",
+		},
+	}
+
+	required := normalizeExtrasSelections(pkgs, []domain.ExtrasSelection{
+		{
+			Name:         "evolution-cms/etinymce",
+			Source:       "composer-require",
+			Version:      "*",
+			ComposerName: "evolution-cms/etinymce",
+			Required:     true,
+		},
+	})
+	selected := mergeRequiredExtras([]domain.ExtrasSelection{{ID: "managed:eTinyMCE"}}, required)
+	selected = normalizeExtrasSelections(pkgs, selected)
+
+	if len(selected) != 1 {
+		t.Fatalf("expected duplicate required extra to collapse to one install item, got %#v", selected)
+	}
+	if selected[0].Name != "eTinyMCE" || !selected[0].Required {
+		t.Fatalf("expected deduped extra to stay required, got %#v", selected[0])
+	}
+}
+
 func TestParsePresetRequiredExtrasSupportsStringsAndObjects(t *testing.T) {
 	t.Parallel()
 
@@ -257,6 +374,49 @@ func TestParsePresetRequiredExtrasSupportsStringsAndObjects(t *testing.T) {
 	}
 	if selections[2].Name != "ePasskeys" || selections[2].Version != "main" || !selections[2].Required {
 		t.Fatalf("unexpected third selection: %#v", selections[2])
+	}
+}
+
+func TestParseComposerRequiredExtrasUsesComposerRequire(t *testing.T) {
+	t.Parallel()
+
+	selections, err := parseComposerRequiredExtras([]byte(`{
+		"require": {
+			"php": "^8.3",
+			"evolution-cms/etinymce": "*"
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parseComposerRequiredExtras returned error: %v", err)
+	}
+	if len(selections) != 1 {
+		t.Fatalf("expected one composer-backed selection, got %#v", selections)
+	}
+	if selections[0].ComposerName != "evolution-cms/etinymce" || selections[0].Version != "*" || !selections[0].Required {
+		t.Fatalf("unexpected composer selection: %#v", selections[0])
+	}
+}
+
+func TestEnrichManagedExtrasComposerNamesFromCatalogCache(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "core", "custom", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(`{
+		"packages": [
+			{"name": "eTinyMCE", "composer_name": "evolution-cms/etinymce"}
+		]
+	}`)
+	if err := os.WriteFile(filepath.Join(cacheDir, "extras.catalog.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs := enrichManagedExtrasComposerNames(root, []domain.ExtrasPackage{{Name: "eTinyMCE", Source: "managed"}})
+	if len(pkgs) != 1 || pkgs[0].ComposerName != "evolution-cms/etinymce" {
+		t.Fatalf("expected composer name from cache, got %#v", pkgs)
 	}
 }
 

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -189,6 +189,32 @@ func TestDefaultExtrasSelectionsUseFloatingManagedConstraint(t *testing.T) {
 	}
 }
 
+func TestDedupeExtrasPackagesPrefersManagedOverLegacyDuplicate(t *testing.T) {
+	t.Parallel()
+
+	pkgs := dedupeExtrasPackages([]domain.ExtrasPackage{
+		{ID: "legacy-store:1", Name: "TinyMCE4", Source: "legacy-store"},
+		{ID: "managed:TinyMCE4", Name: "TinyMCE4", Source: "managed"},
+		{ID: "legacy-store:2", Name: "AjaxSearch", Source: "legacy-store"},
+	})
+
+	if len(pkgs) != 2 {
+		t.Fatalf("expected 2 unique packages, got %#v", pkgs)
+	}
+	foundTiny := false
+	for _, pkg := range pkgs {
+		if pkg.Name == "TinyMCE4" {
+			foundTiny = true
+			if pkg.Source != "managed" {
+				t.Fatalf("expected managed TinyMCE4 to win, got %#v", pkg)
+			}
+		}
+	}
+	if !foundTiny {
+		t.Fatalf("expected TinyMCE4 in deduped packages: %#v", pkgs)
+	}
+}
+
 func TestParseExtrasDocblockFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -62,11 +62,11 @@ func TestParseLegacyStoreCatalogJSON(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`{
-		"category":[{"id":"2","title":"Catalog"}],
+		"category":[{"id":2,"title":"Catalog"}],
 		"allcategory":{
 			"2":[
 				{
-					"id":"84",
+					"id":84,
 					"url":{"fieldValue":[
 						{"file":"https://github.com/extras-evolution/ajaxSearch/archive/1.12.2.zip","version":"1.12.2","date":"25-01-2021"},
 						{"file":"https://github.com/extras-evolution/ajaxSearch/archive/master.zip","version":"master","date":"04-11-2017"}

--- a/internal/engine/install/preset_extras.go
+++ b/internal/engine/install/preset_extras.go
@@ -17,11 +17,16 @@ type presetExtrasManifest struct {
 	} `json:"extras"`
 }
 
+type presetComposerManifest struct {
+	Require map[string]string `json:"require"`
+}
+
 type presetExtraRef struct {
-	ID      string
-	Name    string
-	Source  string
-	Version string
+	ID           string
+	Name         string
+	Source       string
+	Version      string
+	ComposerName string
 }
 
 func (r *presetExtraRef) UnmarshalJSON(raw []byte) error {
@@ -61,6 +66,10 @@ func presetExtraRefFromString(value string) presetExtraRef {
 	ref := presetExtraRef{Version: version}
 	if strings.Contains(name, ":") {
 		ref.ID = name
+	} else if strings.Contains(name, "/") {
+		ref.Name = name
+		ref.Source = "composer-require"
+		ref.ComposerName = normalizeComposerPackageName(name)
 	} else {
 		ref.Name = name
 	}
@@ -68,24 +77,31 @@ func presetExtraRefFromString(value string) presetExtraRef {
 }
 
 func loadPresetRequiredExtras(workDir string) ([]domain.ExtrasSelection, []string) {
+	var out []domain.ExtrasSelection
+	var warnings []string
+
+	composerSelections, composerWarnings := loadComposerRequiredExtras(workDir)
+	warnings = append(warnings, composerWarnings...)
+	out = mergeRequiredExtras(out, composerSelections)
+
 	for _, path := range presetManifestPaths(workDir) {
 		raw, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, []string{"Unable to read preset extras manifest: " + err.Error()}
+			warnings = append(warnings, "Unable to read preset extras manifest: "+err.Error())
+			continue
 		}
 
 		selections, err := parsePresetRequiredExtras(raw)
 		if err != nil {
-			return nil, []string{fmt.Sprintf("Invalid preset extras manifest %s: %v", filepath.ToSlash(path), err)}
+			warnings = append(warnings, fmt.Sprintf("Invalid preset extras manifest %s: %v", filepath.ToSlash(path), err))
+			continue
 		}
-		if len(selections) > 0 {
-			return selections, nil
-		}
+		out = mergeRequiredExtras(out, selections)
 	}
-	return nil, nil
+	return out, warnings
 }
 
 func presetManifestPaths(workDir string) []string {
@@ -110,11 +126,65 @@ func parsePresetRequiredExtras(raw []byte) ([]domain.ExtrasSelection, error) {
 	seen := map[string]struct{}{}
 	for _, ref := range refs {
 		sel := domain.ExtrasSelection{
-			ID:       strings.TrimSpace(ref.ID),
-			Name:     strings.TrimSpace(ref.Name),
-			Source:   strings.TrimSpace(ref.Source),
-			Version:  strings.TrimSpace(ref.Version),
-			Required: true,
+			ID:           strings.TrimSpace(ref.ID),
+			Name:         strings.TrimSpace(ref.Name),
+			Source:       strings.TrimSpace(ref.Source),
+			Version:      strings.TrimSpace(ref.Version),
+			ComposerName: normalizeComposerPackageName(ref.ComposerName),
+			Required:     true,
+		}
+		if sel.ComposerName == "" && strings.Contains(sel.Name, "/") {
+			sel.ComposerName = normalizeComposerPackageName(sel.Name)
+		}
+		key := extrasSelectionIdentity(sel)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, sel)
+	}
+	return out, nil
+}
+
+func loadComposerRequiredExtras(workDir string) ([]domain.ExtrasSelection, []string) {
+	path := filepath.Join(absDir(workDir), "core", "custom", "composer.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []string{"Unable to read preset composer requirements: " + err.Error()}
+	}
+
+	selections, err := parseComposerRequiredExtras(raw)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("Invalid preset composer requirements %s: %v", filepath.ToSlash(path), err)}
+	}
+	return selections, nil
+}
+
+func parseComposerRequiredExtras(raw []byte) ([]domain.ExtrasSelection, error) {
+	var manifest presetComposerManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, err
+	}
+
+	out := make([]domain.ExtrasSelection, 0, len(manifest.Require))
+	seen := map[string]struct{}{}
+	for packageName, version := range manifest.Require {
+		composerName := normalizeComposerPackageName(packageName)
+		if composerName == "" {
+			continue
+		}
+		sel := domain.ExtrasSelection{
+			Name:         composerName,
+			Source:       "composer-require",
+			Version:      strings.TrimSpace(version),
+			ComposerName: composerName,
+			Required:     true,
 		}
 		key := extrasSelectionIdentity(sel)
 		if key == "" {

--- a/internal/engine/install/preset_extras.go
+++ b/internal/engine/install/preset_extras.go
@@ -1,0 +1,130 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/evolution-cms/installer/internal/domain"
+)
+
+type presetExtrasManifest struct {
+	RequiredExtras []presetExtraRef `json:"requiredExtras"`
+	Extras         struct {
+		Required []presetExtraRef `json:"required"`
+	} `json:"extras"`
+}
+
+type presetExtraRef struct {
+	ID      string
+	Name    string
+	Source  string
+	Version string
+}
+
+func (r *presetExtraRef) UnmarshalJSON(raw []byte) error {
+	var value string
+	if err := json.Unmarshal(raw, &value); err == nil {
+		*r = presetExtraRefFromString(value)
+		return nil
+	}
+
+	var object struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		Package string `json:"package"`
+		Source  string `json:"source"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return err
+	}
+
+	name := strings.TrimSpace(object.Name)
+	if name == "" {
+		name = strings.TrimSpace(object.Package)
+	}
+
+	*r = presetExtraRef{
+		ID:      strings.TrimSpace(object.ID),
+		Name:    name,
+		Source:  strings.TrimSpace(object.Source),
+		Version: strings.TrimSpace(object.Version),
+	}
+	return nil
+}
+
+func presetExtraRefFromString(value string) presetExtraRef {
+	name, version := splitSelectionValue(value)
+	ref := presetExtraRef{Version: version}
+	if strings.Contains(name, ":") {
+		ref.ID = name
+	} else {
+		ref.Name = name
+	}
+	return ref
+}
+
+func loadPresetRequiredExtras(workDir string) ([]domain.ExtrasSelection, []string) {
+	for _, path := range presetManifestPaths(workDir) {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, []string{"Unable to read preset extras manifest: " + err.Error()}
+		}
+
+		selections, err := parsePresetRequiredExtras(raw)
+		if err != nil {
+			return nil, []string{fmt.Sprintf("Invalid preset extras manifest %s: %v", filepath.ToSlash(path), err)}
+		}
+		if len(selections) > 0 {
+			return selections, nil
+		}
+	}
+	return nil, nil
+}
+
+func presetManifestPaths(workDir string) []string {
+	root := absDir(workDir)
+	return []string{
+		filepath.Join(root, "core", "custom", "preset.json"),
+		filepath.Join(root, "core", "custom", "evo-preset.json"),
+		filepath.Join(root, "core", "custom", "config", "evo-preset.json"),
+	}
+}
+
+func parsePresetRequiredExtras(raw []byte) ([]domain.ExtrasSelection, error) {
+	var manifest presetExtrasManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, err
+	}
+
+	refs := append([]presetExtraRef{}, manifest.RequiredExtras...)
+	refs = append(refs, manifest.Extras.Required...)
+
+	out := make([]domain.ExtrasSelection, 0, len(refs))
+	seen := map[string]struct{}{}
+	for _, ref := range refs {
+		sel := domain.ExtrasSelection{
+			ID:       strings.TrimSpace(ref.ID),
+			Name:     strings.TrimSpace(ref.Name),
+			Source:   strings.TrimSpace(ref.Source),
+			Version:  strings.TrimSpace(ref.Version),
+			Required: true,
+		}
+		key := extrasSelectionIdentity(sel)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, sel)
+	}
+	return out, nil
+}

--- a/internal/engine/mock/engine.go
+++ b/internal/engine/mock/engine.go
@@ -71,11 +71,12 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, _ <-chan domai
 				Steps: []domain.StepState{
 					{ID: "php", Label: "Step 1: Validate PHP version", Status: domain.StepPending},
 					{ID: "database", Label: "Step 2: Check database connection", Status: domain.StepPending},
-					{ID: "download", Label: "Step 3: Download Evolution CMS", Status: domain.StepPending},
-					{ID: "install", Label: "Step 4: Install Evolution CMS", Status: domain.StepPending},
-					{ID: "presets", Label: "Step 5: Install presets", Status: domain.StepPending},
-					{ID: "finalize", Label: "Step 6: Finalize installation", Status: domain.StepPending},
-					{ID: "extras", Label: "Step 7: Install Extras (optional)", Status: domain.StepPending},
+					{ID: "project_preset", Label: "Step 3: Choose project preset", Status: domain.StepPending},
+					{ID: "download", Label: "Step 4: Download Evolution CMS", Status: domain.StepPending},
+					{ID: "install", Label: "Step 5: Install Evolution CMS", Status: domain.StepPending},
+					{ID: "presets", Label: "Step 6: Apply project preset", Status: domain.StepPending},
+					{ID: "finalize", Label: "Step 7: Finalize installation", Status: domain.StepPending},
+					{ID: "extras", Label: "Step 8: Install Extras (optional)", Status: domain.StepPending},
 				},
 			},
 		})
@@ -285,11 +286,12 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, _ <-chan domai
 		}{
 			{"php", "Step 1: Validate PHP version"},
 			{"database", "Step 2: Check database connection"},
-			{"download", "Step 3: Download Evolution CMS"},
-			{"install", "Step 4: Install Evolution CMS"},
-			{"presets", "Step 5: Install presets"},
-			{"finalize", "Step 6: Finalize installation"},
-			{"extras", "Step 7: Install Extras (optional)"},
+			{"project_preset", "Step 3: Choose project preset"},
+			{"download", "Step 4: Download Evolution CMS"},
+			{"install", "Step 5: Install Evolution CMS"},
+			{"presets", "Step 6: Apply project preset"},
+			{"finalize", "Step 7: Finalize installation"},
+			{"extras", "Step 8: Install Extras (optional)"},
 		}
 
 		for i, s := range steps {

--- a/internal/engine/mock/engine.go
+++ b/internal/engine/mock/engine.go
@@ -74,9 +74,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, _ <-chan domai
 					{ID: "project_preset", Label: "Step 3: Choose project preset", Status: domain.StepPending},
 					{ID: "download", Label: "Step 4: Download Evolution CMS", Status: domain.StepPending},
 					{ID: "install", Label: "Step 5: Install Evolution CMS", Status: domain.StepPending},
-					{ID: "presets", Label: "Step 6: Apply project preset", Status: domain.StepPending},
-					{ID: "finalize", Label: "Step 7: Finalize installation", Status: domain.StepPending},
-					{ID: "extras", Label: "Step 8: Install Extras (optional)", Status: domain.StepPending},
+					{ID: "finalize", Label: "Step 6: Finalize installation", Status: domain.StepPending},
+					{ID: "extras", Label: "Step 7: Install Extras", Status: domain.StepPending},
 				},
 			},
 		})
@@ -289,9 +288,8 @@ func (e *Engine) Run(ctx context.Context, ch chan<- domain.Event, _ <-chan domai
 			{"project_preset", "Step 3: Choose project preset"},
 			{"download", "Step 4: Download Evolution CMS"},
 			{"install", "Step 5: Install Evolution CMS"},
-			{"presets", "Step 6: Apply project preset"},
-			{"finalize", "Step 7: Finalize installation"},
-			{"extras", "Step 8: Install Extras (optional)"},
+			{"finalize", "Step 6: Finalize installation"},
+			{"extras", "Step 7: Install Extras"},
 		}
 
 		for i, s := range steps {

--- a/internal/services/github/releases.go
+++ b/internal/services/github/releases.go
@@ -19,6 +19,15 @@ type GitHubRelease struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
+type GitHubRepository struct {
+	Name        string `json:"name"`
+	FullName    string `json:"full_name"`
+	Description string `json:"description"`
+	HTMLURL     string `json:"html_url"`
+	Private     bool   `json:"private"`
+	Archived    bool   `json:"archived"`
+}
+
 func FetchLatestRelease(ctx context.Context, owner string, repo string) (GitHubRelease, error) {
 	u := url.URL{
 		Scheme: "https",
@@ -110,4 +119,64 @@ func FetchReleasesPage(ctx context.Context, owner string, repo string, page int)
 		return nil, err
 	}
 	return releases, nil
+}
+
+func FetchOrgRepositories(ctx context.Context, org string) ([]GitHubRepository, error) {
+	const maxPages = 3
+	var out []GitHubRepository
+	for page := 1; page <= maxPages; page++ {
+		items, err := FetchOrgRepositoriesPage(ctx, org, page)
+		if err != nil {
+			return nil, err
+		}
+		if len(items) == 0 {
+			break
+		}
+		out = append(out, items...)
+	}
+	return out, nil
+}
+
+func FetchOrgRepositoriesPage(ctx context.Context, org string, page int) ([]GitHubRepository, error) {
+	if page < 1 {
+		page = 1
+	}
+	u := url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   fmt.Sprintf("/orgs/%s/repos", org),
+	}
+	q := u.Query()
+	q.Set("per_page", "100")
+	q.Set("page", strconv.Itoa(page))
+	q.Set("type", "public")
+	q.Set("sort", "full_name")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "evo-installer")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 12 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github org repositories: %s", resp.Status)
+	}
+
+	var repos []GitHubRepository
+	if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
+		return nil, err
+	}
+	return repos, nil
 }

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -546,7 +546,7 @@ func buildExtrasVersionOptions(pkg domain.ExtrasPackage) ([]string, []string) {
 
 	defaultLabel := "Default (auto)"
 	if isManagedExtrasPackage(pkg) {
-		defaultLabel = "Default (*)"
+		defaultLabel = "Default (" + domain.DefaultExtrasInstallVersion(pkg) + ")"
 	} else {
 		if v := strings.TrimSpace(pkg.Version); v != "" {
 			defaultLabel += " - " + v
@@ -558,10 +558,18 @@ func buildExtrasVersionOptions(pkg domain.ExtrasPackage) ([]string, []string) {
 	values = append(values, "")
 
 	seen := map[string]struct{}{}
+	if isManagedExtrasPackage(pkg) {
+		if v := strings.TrimSpace(domain.DefaultExtrasInstallVersion(pkg)); v != "" {
+			seen[v] = struct{}{}
+		}
+	}
 	add := func(v string) {
 		v = strings.TrimSpace(v)
 		if v == "" {
 			return
+		}
+		if isManagedExtrasPackage(pkg) {
+			v = strings.TrimSpace(domain.NormalizeExtrasInstallVersion(pkg, v))
 		}
 		if _, ok := seen[v]; ok {
 			return
@@ -581,9 +589,7 @@ func buildExtrasVersionOptions(pkg domain.ExtrasPackage) ([]string, []string) {
 }
 
 func isManagedExtrasPackage(pkg domain.ExtrasPackage) bool {
-	source := strings.ToLower(strings.TrimSpace(pkg.Source))
-	mode := strings.ToLower(strings.TrimSpace(pkg.InstallMode))
-	return source == "managed" || mode == "managed-artisan"
+	return domain.IsManagedExtrasPackage(pkg)
 }
 
 func (m *Model) extrasListHeight() int {
@@ -1032,7 +1038,7 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		}
 		if version == "" {
 			if isManagedExtrasPackage(pkg) {
-				version = "*"
+				version = domain.DefaultExtrasInstallVersion(pkg)
 			} else {
 				version = strings.TrimSpace(pkg.Version)
 				if version == "" {

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -457,10 +457,14 @@ func buildExtrasVersionOptions(pkg domain.ExtrasPackage) ([]string, []string) {
 	values := []string{}
 
 	defaultLabel := "Default (auto)"
-	if v := strings.TrimSpace(pkg.Version); v != "" {
-		defaultLabel += " - " + v
-	} else if b := strings.TrimSpace(pkg.DefaultBranch); b != "" {
-		defaultLabel += " - " + b
+	if isManagedExtrasPackage(pkg) {
+		defaultLabel = "Default (*)"
+	} else {
+		if v := strings.TrimSpace(pkg.Version); v != "" {
+			defaultLabel += " - " + v
+		} else if b := strings.TrimSpace(pkg.DefaultBranch); b != "" {
+			defaultLabel += " - " + b
+		}
 	}
 	labels = append(labels, defaultLabel)
 	values = append(values, "")
@@ -486,6 +490,12 @@ func buildExtrasVersionOptions(pkg domain.ExtrasPackage) ([]string, []string) {
 	add(pkg.DefaultBranch)
 
 	return labels, values
+}
+
+func isManagedExtrasPackage(pkg domain.ExtrasPackage) bool {
+	source := strings.ToLower(strings.TrimSpace(pkg.Source))
+	mode := strings.ToLower(strings.TrimSpace(pkg.InstallMode))
+	return source == "managed" || mode == "managed-artisan"
 }
 
 func (m *Model) extrasListHeight() int {
@@ -931,13 +941,17 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 			version = strings.TrimSpace(m.extras.versions[key])
 		}
 		if version == "" {
-			version = strings.TrimSpace(pkg.Version)
-		}
-		if version == "" {
-			version = strings.TrimSpace(pkg.DefaultBranch)
-		}
-		if version == "" {
-			version = "default"
+			if isManagedExtrasPackage(pkg) {
+				version = "*"
+			} else {
+				version = strings.TrimSpace(pkg.Version)
+				if version == "" {
+					version = strings.TrimSpace(pkg.DefaultBranch)
+				}
+				if version == "" {
+					version = "default"
+				}
+			}
 		}
 		desc := strings.TrimSpace(pkg.Description)
 		label := fmt.Sprintf("%s %s %s%s @ %s", cursor, checked, extrasSourcePrefix(pkg), pkg.Name, version)

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -292,7 +292,11 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 		if listLen == 0 || m.extras.cursor < 0 || m.extras.cursor >= listLen {
 			return
 		}
-		key := extrasPackageKey(visiblePackages[m.extras.cursor])
+		pkg := visiblePackages[m.extras.cursor]
+		if pkg.Required {
+			return
+		}
+		key := extrasPackageKey(pkg)
 		if key == "" {
 			return
 		}
@@ -411,21 +415,21 @@ func (m *Model) handleExtrasSummaryKey(lowerKey string) {
 }
 
 func (m *Model) extrasSelectedNames() []domain.ExtrasSelection {
-	if len(m.extras.packages) == 0 || len(m.extras.selected) == 0 {
+	if len(m.extras.packages) == 0 {
 		return nil
 	}
-	out := make([]domain.ExtrasSelection, 0, len(m.extras.selected))
+	out := make([]domain.ExtrasSelection, 0, len(m.extras.packages))
 	for _, pkg := range m.extras.packages {
 		key := extrasPackageKey(pkg)
 		if key == "" {
 			continue
 		}
-		if m.extras.selected[key] {
+		if pkg.Required || (m.extras.selected != nil && m.extras.selected[key]) {
 			version := ""
 			if m.extras.versions != nil {
 				version = strings.TrimSpace(m.extras.versions[key])
 			}
-			out = append(out, domain.ExtrasSelection{ID: key, Name: pkg.Name, Source: pkg.Source, Version: version})
+			out = append(out, domain.ExtrasSelection{ID: key, Name: pkg.Name, Source: pkg.Source, Version: version, Required: pkg.Required})
 		}
 	}
 	return out
@@ -1028,7 +1032,9 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		}
 
 		checked := "[ ]"
-		if m.extras.selected != nil && m.extras.selected[key] {
+		if pkg.Required {
+			checked = "[!]"
+		} else if m.extras.selected != nil && m.extras.selected[key] {
 			checked = "[x]"
 		}
 
@@ -1051,6 +1057,9 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		}
 		desc := strings.TrimSpace(pkg.Description)
 		label := fmt.Sprintf("%s %s %s%s @ %s", cursor, checked, extrasSourcePrefix(pkg), pkg.Name, version)
+		if pkg.Required {
+			label += " (required by preset)"
+		}
 		if desc != "" {
 			label += " - " + desc
 		}
@@ -1340,6 +1349,9 @@ func (m *Model) renderExtrasSelectActions(width int) string {
 	selected := m.extrasSelectedNames()
 	installLabel := fmt.Sprintf(" Install selected (%d) ", len(selected))
 	skipLabel := " Skip extras "
+	if m.hasRequiredExtras() {
+		skipLabel = " Install required only "
+	}
 	legacyLabel := " Show Legacy Store "
 	if m.extras.showLegacy {
 		legacyLabel = " Hide Legacy Store "
@@ -1375,6 +1387,15 @@ func (m *Model) renderExtrasSelectActions(width int) string {
 	legacy := legacyStyle.Render("[" + legacyLabel + "]")
 	line := install + "  " + skip + "  " + legacy
 	return padRight(truncateANSI(line, width), width)
+}
+
+func (m *Model) hasRequiredExtras() bool {
+	for _, pkg := range m.extras.packages {
+		if pkg.Required {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Model) renderExtrasSummaryActions(width int) string {

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -35,6 +35,10 @@ type extrasUIState struct {
 	focus    extrasFocus
 	action   int
 
+	showLegacy   bool
+	searchActive bool
+	searchQuery  string
+
 	versionPickerActive  bool
 	versionPickerPkg     string
 	versionPickerCursor  int
@@ -87,15 +91,23 @@ func (m *Model) applyExtrasState(state domain.ExtrasState) {
 				}
 			}
 			m.extras.cursor = 0
-			m.extras.focus = extrasFocusList
-			m.extras.action = 0
+			m.extras.focus = extrasFocusActions
+			if len(state.Selections) > 0 {
+				m.extras.action = 0
+			} else {
+				m.extras.action = 1
+			}
 			m.extras.versionPickerActive = false
+			m.extras.showLegacy = false
+			m.extras.searchActive = false
+			m.extras.searchQuery = ""
 		}
-		if len(m.extras.packages) == 0 {
+		visibleCount := len(m.visibleExtrasPackages())
+		if visibleCount == 0 {
 			m.extras.cursor = 0
 			m.extras.focus = extrasFocusActions
-		} else if m.extras.cursor >= len(m.extras.packages) {
-			m.extras.cursor = len(m.extras.packages) - 1
+		} else if m.extras.cursor >= visibleCount {
+			m.extras.cursor = visibleCount - 1
 		}
 		return
 	}
@@ -170,7 +182,12 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 		m.handleExtrasVersionPickerKey(lowerKey)
 		return
 	}
-	listLen := len(m.extras.packages)
+	if m.extras.searchActive {
+		m.handleExtrasSearchKey(key, lowerKey)
+		return
+	}
+	visiblePackages := m.visibleExtrasPackages()
+	listLen := len(visiblePackages)
 	listHeight := m.extrasListHeight()
 
 	toggleFocus := func() {
@@ -188,6 +205,15 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 	case "shift+tab":
 		toggleFocus()
 		return
+	case "/":
+		m.extras.searchActive = true
+		if len(m.extras.searchQuery) > 0 {
+			m.extras.focus = extrasFocusList
+		}
+		return
+	case "l":
+		m.toggleExtrasLegacy()
+		return
 	}
 
 	if m.extras.focus == extrasFocusActions {
@@ -200,15 +226,14 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 				}
 			}
 			return
-		case "left", "right", "tab", "shift+tab":
-			if m.extras.action == 0 {
-				m.extras.action = 1
-			} else {
-				m.extras.action = 0
-			}
+		case "left":
+			m.extras.action--
+		case "right", "tab", "shift+tab":
+			m.extras.action++
 		case "enter":
 			selected := m.extrasSelectedNames()
-			if m.extras.action == 0 {
+			switch m.extras.action {
+			case 0:
 				if len(selected) == 0 {
 					return
 				}
@@ -220,6 +245,9 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 					Extras:     selected,
 				})
 				return
+			case 2:
+				m.toggleExtrasLegacy()
+				return
 			}
 			m.sendAction(domain.Action{
 				Type:       domain.ActionExtrasDecision,
@@ -227,6 +255,7 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 				OptionID:   uiExtrasSkip,
 			})
 		}
+		m.clampExtrasAction()
 		return
 	}
 
@@ -256,14 +285,14 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 		if listLen == 0 || m.extras.cursor < 0 || m.extras.cursor >= listLen {
 			return
 		}
-		pkg := m.extras.packages[m.extras.cursor]
+		pkg := visiblePackages[m.extras.cursor]
 		m.openExtrasVersionPicker(pkg)
 		return
 	case " ":
 		if listLen == 0 || m.extras.cursor < 0 || m.extras.cursor >= listLen {
 			return
 		}
-		key := extrasPackageKey(m.extras.packages[m.extras.cursor])
+		key := extrasPackageKey(visiblePackages[m.extras.cursor])
 		if key == "" {
 			return
 		}
@@ -290,6 +319,65 @@ func (m *Model) handleExtrasSelectKey(key string, lowerKey string) {
 	if m.extras.cursor >= listLen {
 		m.extras.cursor = listLen - 1
 	}
+}
+
+func (m *Model) handleExtrasSearchKey(key string, lowerKey string) {
+	switch lowerKey {
+	case "esc":
+		m.extras.searchActive = false
+		return
+	case "enter":
+		m.extras.searchActive = false
+		if len(m.visibleExtrasPackages()) > 0 {
+			m.extras.focus = extrasFocusList
+		}
+		return
+	case "ctrl+u":
+		m.extras.searchQuery = ""
+	case "backspace", "ctrl+h":
+		rs := []rune(m.extras.searchQuery)
+		if len(rs) > 0 {
+			m.extras.searchQuery = string(rs[:len(rs)-1])
+		}
+	default:
+		if len(key) == 1 && key != "/" {
+			m.extras.searchQuery += key
+		}
+	}
+	m.extras.cursor = 0
+	if len(m.visibleExtrasPackages()) == 0 {
+		m.extras.focus = extrasFocusActions
+	} else {
+		m.extras.focus = extrasFocusList
+	}
+}
+
+func (m *Model) toggleExtrasLegacy() {
+	m.extras.showLegacy = !m.extras.showLegacy
+	m.extras.cursor = 0
+	if len(m.visibleExtrasPackages()) > 0 {
+		m.extras.focus = extrasFocusList
+	} else {
+		m.extras.focus = extrasFocusActions
+	}
+}
+
+func (m *Model) clampExtrasAction() {
+	count := extrasActionCount()
+	if count <= 0 {
+		m.extras.action = 0
+		return
+	}
+	for m.extras.action < 0 {
+		m.extras.action += count
+	}
+	if m.extras.action >= count {
+		m.extras.action = m.extras.action % count
+	}
+}
+
+func extrasActionCount() int {
+	return 3
 }
 
 func (m *Model) handleExtrasSummaryKey(lowerKey string) {
@@ -535,6 +623,7 @@ func (m *Model) renderExtrasSelect(width int, height int) string {
 
 	lines := []string{
 		truncatePlain("Select extras to install.", contentW),
+		truncatePlain(m.extrasFilterLine(), contentW),
 		"",
 	}
 
@@ -888,21 +977,22 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 	if height <= 0 || width <= 0 {
 		return nil
 	}
-	if len(m.extras.packages) == 0 {
+	packages := m.visibleExtrasPackages()
+	if len(packages) == 0 {
 		return fitLines("(no extras found)", width, height)
 	}
 
 	visible := height
-	if visible > len(m.extras.packages) {
-		visible = len(m.extras.packages)
+	if visible > len(packages) {
+		visible = len(packages)
 	}
 	start := 0
-	if len(m.extras.packages) > visible {
+	if len(packages) > visible {
 		start = m.extras.cursor - visible/2
 		if start < 0 {
 			start = 0
 		}
-		maxStart := len(m.extras.packages) - visible
+		maxStart := len(packages) - visible
 		if start > maxStart {
 			start = maxStart
 		}
@@ -912,7 +1002,7 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 	currentSection := ""
 	for i := 0; i < visible; i++ {
 		idx := start + i
-		pkg := m.extras.packages[idx]
+		pkg := packages[idx]
 		key := extrasPackageKey(pkg)
 		section := strings.TrimSpace(pkg.Section)
 		if section != "" && section != currentSection && len(out) < height {
@@ -967,6 +1057,52 @@ func (m *Model) renderExtrasList(width int, height int) []string {
 		out = append(out, "")
 	}
 	return out[:height]
+}
+
+func (m *Model) extrasFilterLine() string {
+	source := "Bundled + Managed"
+	if m.extras.showLegacy {
+		source = "Bundled + Managed + Legacy Store"
+	}
+	query := strings.TrimSpace(m.extras.searchQuery)
+	if query == "" {
+		if m.extras.searchActive {
+			query = "typing..."
+		} else {
+			query = "none"
+		}
+	}
+	return fmt.Sprintf("Source: %s   Search: %s", source, query)
+}
+
+func (m *Model) visibleExtrasPackages() []domain.ExtrasPackage {
+	if len(m.extras.packages) == 0 {
+		return nil
+	}
+	query := strings.ToLower(strings.TrimSpace(m.extras.searchQuery))
+	out := make([]domain.ExtrasPackage, 0, len(m.extras.packages))
+	for _, pkg := range m.extras.packages {
+		if !m.extras.showLegacy && strings.TrimSpace(pkg.Source) == "legacy-store" {
+			continue
+		}
+		if query != "" && !extrasPackageMatchesQuery(pkg, query) {
+			continue
+		}
+		out = append(out, pkg)
+	}
+	return out
+}
+
+func extrasPackageMatchesQuery(pkg domain.ExtrasPackage, query string) bool {
+	haystack := strings.ToLower(strings.Join([]string{
+		pkg.Name,
+		pkg.Description,
+		pkg.Section,
+		pkg.Source,
+		pkg.Kind,
+		pkg.LegacyNames,
+	}, " "))
+	return strings.Contains(haystack, query)
 }
 
 func extrasPackageKey(pkg domain.ExtrasPackage) string {
@@ -1196,19 +1332,31 @@ func extrasStatusMarker(status domain.ExtrasItemStatus) (string, lipgloss.Style)
 
 func (m *Model) renderExtrasSelectActions(width int) string {
 	selected := m.extrasSelectedNames()
-	installLabel := " Install selected "
-	skipLabel := " Back/Skip "
+	installLabel := fmt.Sprintf(" Install selected (%d) ", len(selected))
+	skipLabel := " Skip extras "
+	legacyLabel := " Show Legacy Store "
+	if m.extras.showLegacy {
+		legacyLabel = " Hide Legacy Store "
+	}
 
 	installStyle := mutedStyle
 	skipStyle := mutedStyle
+	legacyStyle := mutedStyle
 
 	if m.extras.focus == extrasFocusActions {
-		if m.extras.action == 0 {
+		switch m.extras.action {
+		case 0:
 			installStyle = okStyle.Copy().Bold(true)
 			skipStyle = mutedStyle
-		} else {
+			legacyStyle = mutedStyle
+		case 1:
 			skipStyle = warnStyle.Copy().Bold(true)
 			installStyle = mutedStyle
+			legacyStyle = mutedStyle
+		case 2:
+			legacyStyle = inputStyle.Copy().Bold(true)
+			installStyle = mutedStyle
+			skipStyle = mutedStyle
 		}
 	}
 
@@ -1218,7 +1366,8 @@ func (m *Model) renderExtrasSelectActions(width int) string {
 
 	install := installStyle.Render("[" + installLabel + "]")
 	skip := skipStyle.Render("[" + skipLabel + "]")
-	line := install + "  " + skip
+	legacy := legacyStyle.Render("[" + legacyLabel + "]")
+	line := install + "  " + skip + "  " + legacy
 	return padRight(truncateANSI(line, width), width)
 }
 

--- a/internal/ui/extras.go
+++ b/internal/ui/extras.go
@@ -135,7 +135,7 @@ func extrasPackagesEqual(a []domain.ExtrasPackage, b []domain.ExtrasPackage) boo
 		return false
 	}
 	for i := range a {
-		if a[i].ID != b[i].ID || a[i].Name != b[i].Name || a[i].Version != b[i].Version || a[i].Source != b[i].Source || a[i].Section != b[i].Section || a[i].Preselected != b[i].Preselected {
+		if a[i].ID != b[i].ID || a[i].Name != b[i].Name || a[i].Version != b[i].Version || a[i].Source != b[i].Source || a[i].Section != b[i].Section || a[i].Preselected != b[i].Preselected || a[i].ComposerName != b[i].ComposerName {
 			return false
 		}
 		if len(a[i].Versions) != len(b[i].Versions) {
@@ -456,6 +456,9 @@ func selectionsToValues(selections []domain.ExtrasSelection) []string {
 }
 
 func (m *Model) openExtrasVersionPicker(pkg domain.ExtrasPackage) {
+	if pkg.Required {
+		return
+	}
 	key := extrasPackageKey(pkg)
 	if key == "" {
 		return

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -26,3 +26,20 @@ func TestHandleExtrasSelectKeyRightMovesFocusToInstallAction(t *testing.T) {
 		t.Fatalf("expected install action to be selected, got %d", m.extras.action)
 	}
 }
+
+func TestBuildExtrasVersionOptionsShowsManagedDefaultWildcard(t *testing.T) {
+	t.Parallel()
+
+	labels, values := buildExtrasVersionOptions(domain.ExtrasPackage{
+		ID:      "managed:sSeo",
+		Name:    "sSeo",
+		Source:  "managed",
+		Version: "1.2.3",
+	})
+	if len(labels) == 0 || labels[0] != "Default (*)" {
+		t.Fatalf("expected managed default label to use wildcard, got %v", labels)
+	}
+	if len(values) == 0 || values[0] != "" {
+		t.Fatalf("expected managed default value to stay blank for normalization, got %v", values)
+	}
+}

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -75,6 +75,41 @@ func TestRequiredExtrasCannotBeDeselected(t *testing.T) {
 	}
 }
 
+func TestRequiredExtrasVersionPickerStaysLocked(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.applyExtrasState(domain.ExtrasState{
+		Active: true,
+		Stage:  domain.ExtrasStageSelect,
+		Packages: []domain.ExtrasPackage{
+			{
+				ID:                 "managed:eTinyMCE",
+				Name:               "eTinyMCE",
+				Source:             "managed",
+				DefaultInstallMode: "latest-release",
+				Version:            "8.3.2",
+				Required:           true,
+			},
+		},
+		Selections: []domain.ExtrasSelection{
+			{ID: "managed:eTinyMCE", Name: "eTinyMCE", Source: "managed", Version: "*", Required: true},
+		},
+	})
+	m.extras.focus = extrasFocusList
+	m.extras.cursor = 0
+
+	m.handleExtrasSelectKey("v", "v")
+
+	if m.extras.versionPickerActive {
+		t.Fatalf("expected required extra version picker to stay closed")
+	}
+	selected := m.extrasSelectedNames()
+	if len(selected) != 1 || selected[0].Version != "*" || !selected[0].Required {
+		t.Fatalf("expected required extra version to stay locked, got %#v", selected)
+	}
+}
+
 func TestVisibleExtrasPackagesHidesLegacyUntilToggled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -103,3 +103,25 @@ func TestBuildExtrasVersionOptionsShowsManagedDefaultWildcard(t *testing.T) {
 		t.Fatalf("expected managed default value to stay blank for normalization, got %v", values)
 	}
 }
+
+func TestBuildExtrasVersionOptionsShowsManagedDevOnlyDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	labels, values := buildExtrasVersionOptions(domain.ExtrasPackage{
+		ID:            "managed:ePasskeys",
+		Name:          "ePasskeys",
+		Source:        "managed",
+		DefaultBranch: "main",
+	})
+	if len(labels) == 0 || labels[0] != "Default (dev-main)" {
+		t.Fatalf("expected managed dev-only default label to use dev-main, got %v", labels)
+	}
+	if len(values) == 0 || values[0] != "" {
+		t.Fatalf("expected managed default value to stay blank for normalization, got %v", values)
+	}
+	for _, label := range labels[1:] {
+		if label == "main" {
+			t.Fatalf("expected raw default branch to be normalized or skipped, got labels %v", labels)
+		}
+	}
+}

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -50,6 +50,31 @@ func TestApplyExtrasStateDefaultsToInstallAction(t *testing.T) {
 	}
 }
 
+func TestRequiredExtrasCannotBeDeselected(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.applyExtrasState(domain.ExtrasState{
+		Active: true,
+		Stage:  domain.ExtrasStageSelect,
+		Packages: []domain.ExtrasPackage{
+			{ID: "managed:sSeo", Name: "sSeo", Source: "managed", Required: true},
+		},
+		Selections: []domain.ExtrasSelection{
+			{ID: "managed:sSeo", Name: "sSeo", Source: "managed", Required: true},
+		},
+	})
+	m.extras.focus = extrasFocusList
+	m.extras.cursor = 0
+
+	m.handleExtrasSelectKey(" ", " ")
+
+	selected := m.extrasSelectedNames()
+	if len(selected) != 1 || !selected[0].Required || selected[0].Name != "sSeo" {
+		t.Fatalf("expected required sSeo to remain selected, got %#v", selected)
+	}
+}
+
 func TestVisibleExtrasPackagesHidesLegacyUntilToggled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/extras_test.go
+++ b/internal/ui/extras_test.go
@@ -27,6 +27,66 @@ func TestHandleExtrasSelectKeyRightMovesFocusToInstallAction(t *testing.T) {
 	}
 }
 
+func TestApplyExtrasStateDefaultsToInstallAction(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.applyExtrasState(domain.ExtrasState{
+		Active: true,
+		Stage:  domain.ExtrasStageSelect,
+		Packages: []domain.ExtrasPackage{
+			{ID: "bundled-inline:codemirror", Name: "CodeMirror", Source: "bundled-inline"},
+		},
+		Selections: []domain.ExtrasSelection{
+			{ID: "bundled-inline:codemirror", Name: "CodeMirror"},
+		},
+	})
+
+	if m.extras.focus != extrasFocusActions {
+		t.Fatalf("expected actions focus, got %v", m.extras.focus)
+	}
+	if m.extras.action != 0 {
+		t.Fatalf("expected install action, got %d", m.extras.action)
+	}
+}
+
+func TestVisibleExtrasPackagesHidesLegacyUntilToggled(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.extras.packages = []domain.ExtrasPackage{
+		{ID: "managed:sSeo", Name: "sSeo", Source: "managed"},
+		{ID: "legacy-store:84", Name: "AjaxSearch", Source: "legacy-store"},
+	}
+
+	visible := m.visibleExtrasPackages()
+	if len(visible) != 1 || visible[0].Name != "sSeo" {
+		t.Fatalf("expected only non-legacy package, got %#v", visible)
+	}
+
+	m.extras.showLegacy = true
+	visible = m.visibleExtrasPackages()
+	if len(visible) != 2 {
+		t.Fatalf("expected legacy package after toggle, got %#v", visible)
+	}
+}
+
+func TestVisibleExtrasPackagesSearchesNameAndDescription(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{}
+	m.extras.packages = []domain.ExtrasPackage{
+		{ID: "managed:sSeo", Name: "sSeo", Source: "managed", Description: "SEO tools"},
+		{ID: "managed:sArticles", Name: "sArticles", Source: "managed", Description: "Blog"},
+	}
+	m.extras.searchQuery = "seo"
+
+	visible := m.visibleExtrasPackages()
+	if len(visible) != 1 || visible[0].Name != "sSeo" {
+		t.Fatalf("expected search to find sSeo, got %#v", visible)
+	}
+}
+
 func TestBuildExtrasVersionOptionsShowsManagedDefaultWildcard(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -97,7 +97,10 @@ func (m *Model) footerHintText() string {
 		if m.extras.versionPickerActive {
 			return "↑/↓ Move  Enter Select  Esc Close  ctrl+q Quit"
 		}
-		return "↑/↓ Move  Space Toggle  Enter Version  Down Actions  Enter Select  ctrl+c Cancel  ctrl+q Quit"
+		if m.extras.searchActive {
+			return "Type Search  Enter Apply  Esc Close  Ctrl+U Clear  ctrl+c Cancel  ctrl+q Quit"
+		}
+		return "↑/↓ Move  Space Toggle  / Search  L Legacy  Tab Actions  Enter Select  ctrl+c Cancel  ctrl+q Quit"
 	case domain.ExtrasStageProgress:
 		return "Installing extras...  ctrl+c Cancel  ctrl+q Quit"
 	case domain.ExtrasStageSummary:
@@ -259,14 +262,16 @@ func (m *Model) renderLogoHeader(width int) string {
 	}
 
 	versionText, versionLineStyle := m.releaseVersionLine()
+	installerText := m.installerVersionLine()
 	tagline := m.meta.Tagline
 	if tagline == "" {
 		tagline = "The world’s fastest CMS!"
 	}
 	version := versionLineStyle.Render(cutPlain(versionText, availableMetaW))
+	installer := mutedStyle.Render(cutPlain(installerText, availableMetaW))
 	tagline = taglineStyle.Render(cutPlain(tagline, availableMetaW))
 
-	metaBase := []string{version, tagline}
+	metaBase := []string{version, installer, tagline}
 	metaH := len(metaBase)
 	metaTopPad := max(0, (logoH-metaH)/2)
 	metaBottomPad := max(0, logoH-metaH-metaTopPad)
@@ -335,7 +340,8 @@ func (m *Model) renderLogoHeader(width int) string {
 func (m *Model) renderCompactHeader(width int) string {
 	contentW := panelContentWidth(width)
 	versionText, versionLineStyle := m.releaseVersionLine()
-	version := versionLineStyle.Render(cutPlain(versionText, contentW))
+	compact := versionText + " | " + m.installerVersionLine()
+	version := versionLineStyle.Render(cutPlain(compact, contentW))
 	return panel("Evolution CMS Installer", version, width, compactHeaderHeight)
 }
 
@@ -350,6 +356,10 @@ func (m *Model) releaseVersionLine() (string, lipgloss.Style) {
 		return m.appendBranch("v" + m.state.Release.Highest.HighestVersion), versionStyle
 	}
 	return m.appendBranch("v—"), mutedStyle
+}
+
+func (m *Model) installerVersionLine() string {
+	return "Installer " + formatVersion(m.meta.Version)
 }
 
 func (m *Model) appendBranch(versionLine string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -262,16 +262,14 @@ func (m *Model) renderLogoHeader(width int) string {
 	}
 
 	versionText, versionLineStyle := m.releaseVersionLine()
-	installerText := m.installerVersionLine()
 	tagline := m.meta.Tagline
 	if tagline == "" {
 		tagline = "The world’s fastest CMS!"
 	}
 	version := versionLineStyle.Render(cutPlain(versionText, availableMetaW))
-	installer := mutedStyle.Render(cutPlain(installerText, availableMetaW))
 	tagline = taglineStyle.Render(cutPlain(tagline, availableMetaW))
 
-	metaBase := []string{version, installer, tagline}
+	metaBase := []string{version, tagline}
 	metaH := len(metaBase)
 	metaTopPad := max(0, (logoH-metaH)/2)
 	metaBottomPad := max(0, logoH-metaH-metaTopPad)
@@ -334,15 +332,14 @@ func (m *Model) renderLogoHeader(width int) string {
 		outLines = outLines[:innerH]
 	}
 
-	return panel("Evolution CMS Installer", strings.Join(outLines, "\n"), width, logoHeaderHeight)
+	return panel(m.headerTitle(), strings.Join(outLines, "\n"), width, logoHeaderHeight)
 }
 
 func (m *Model) renderCompactHeader(width int) string {
 	contentW := panelContentWidth(width)
 	versionText, versionLineStyle := m.releaseVersionLine()
-	compact := versionText + " | " + m.installerVersionLine()
-	version := versionLineStyle.Render(cutPlain(compact, contentW))
-	return panel("Evolution CMS Installer", version, width, compactHeaderHeight)
+	version := versionLineStyle.Render(cutPlain(versionText, contentW))
+	return panel(m.headerTitle(), version, width, compactHeaderHeight)
 }
 
 func (m *Model) releaseVersionLine() (string, lipgloss.Style) {
@@ -358,8 +355,8 @@ func (m *Model) releaseVersionLine() (string, lipgloss.Style) {
 	return m.appendBranch("v—"), mutedStyle
 }
 
-func (m *Model) installerVersionLine() string {
-	return "Installer " + formatVersion(m.meta.Version)
+func (m *Model) headerTitle() string {
+	return "Evolution CMS Installer " + formatVersion(m.meta.Version)
 }
 
 func (m *Model) appendBranch(versionLine string) string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,0 +1,19 @@
+package ui
+
+import "testing"
+
+func TestHeaderTitleIncludesInstallerVersion(t *testing.T) {
+	m := &Model{meta: Meta{Version: "1.2.3"}}
+
+	if got, want := m.headerTitle(), "Evolution CMS Installer v1.2.3"; got != want {
+		t.Fatalf("headerTitle()=%q, want %q", got, want)
+	}
+}
+
+func TestHeaderTitleFallsBackToDevVersion(t *testing.T) {
+	m := &Model{}
+
+	if got, want := m.headerTitle(), "Evolution CMS Installer dev"; got != want {
+		t.Fatalf("headerTitle()=%q, want %q", got, want)
+	}
+}

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3382,17 +3382,7 @@ class InstallCommand extends Command
         [$source, $ref] = $this->resolveProjectPresetSpec((string) $preset);
         $this->tui->addLog("Installing project preset: {$source}");
 
-        $command = [
-            PHP_BINARY ?: 'php',
-            $artisan,
-            'preset:install',
-            '--from=' . $source,
-            '--force',
-        ];
-
-        if ($ref !== '') {
-            $command[] = '--ref=' . $ref;
-        }
+        $command = $this->buildProjectPresetInstallCommand($artisan, $source, $ref);
 
         $process = new Process($command, $projectPath, $this->buildProcessEnv());
         $timeout = $this->composerTimeoutSeconds();
@@ -3449,6 +3439,27 @@ class InstallCommand extends Command
         $this->steps['presets']['completed'] = true;
         $this->tui->setQuestTrack($this->steps);
         $this->tui->addLog('Project preset installed successfully.', 'success');
+    }
+
+    protected function buildProjectPresetInstallCommand(string $artisan, string $source, string $ref = ''): array
+    {
+        $command = [
+            PHP_BINARY ?: 'php',
+            $artisan,
+            'preset:install',
+            '--from=' . $source,
+            '--force',
+        ];
+
+        if ($ref !== '') {
+            $command[] = '--ref=' . $ref;
+        }
+
+        if (is_dir($source)) {
+            $command[] = '--keep';
+        }
+
+        return $command;
     }
 
     protected function runProjectPresetMigrations(string $projectPath, string $artisan): void

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -62,7 +62,6 @@ class InstallCommand extends Command
             ->addOption('github-pat', null, InputOption::VALUE_OPTIONAL, 'GitHub PAT token for API requests')
             ->addOption('github_pat', null, InputOption::VALUE_OPTIONAL, 'GitHub PAT token for API requests')
             ->addOption('branch', null, InputOption::VALUE_OPTIONAL, 'Install from specific Git branch (e.g., develop, nightly, main) instead of latest release')
-            ->addOption('preset-ref', null, InputOption::VALUE_OPTIONAL, 'Git branch/tag for the project-layer preset')
             ->addOption('language', null, InputOption::VALUE_OPTIONAL, 'The installation language')
             ->addOption('composer-clear-cache', null, InputOption::VALUE_NONE, 'Clear Composer cache before install')
             ->addOption('composer-update', null, InputOption::VALUE_NONE, 'Use composer update instead of install during setup')
@@ -124,7 +123,7 @@ class InstallCommand extends Command
         $this->installEvolutionCMS($name, $options);
 
         // Step 5: Install presets
-        $this->installPreset($input->getOption('preset'), $input->getOption('preset-ref'), $name, $options);
+        $this->installPreset($input->getOption('preset'), $name, $options);
 
         // Step 6: Install dependencies
         $this->installDependencies($name, $options);
@@ -3362,7 +3361,7 @@ class InstallCommand extends Command
     /**
      * Install preset.
      */
-    protected function installPreset(?string $preset, ?string $presetRef, string $name, array $options): void
+    protected function installPreset(?string $preset, string $name, array $options): void
     {
         if ($this->shouldSkipProjectPreset($preset)) {
             $this->steps['presets']['completed'] = true;
@@ -3380,7 +3379,7 @@ class InstallCommand extends Command
             throw new \RuntimeException("Unable to install preset: core/artisan not found in {$projectPath}.");
         }
 
-        $source = $this->resolveProjectPresetSource((string) $preset);
+        [$source, $ref] = $this->resolveProjectPresetSpec((string) $preset);
         $this->tui->addLog("Installing project preset: {$source}");
 
         $command = [
@@ -3391,9 +3390,8 @@ class InstallCommand extends Command
             '--force',
         ];
 
-        $presetRef = trim((string) $presetRef);
-        if ($presetRef !== '') {
-            $command[] = '--ref=' . $presetRef;
+        if ($ref !== '') {
+            $command[] = '--ref=' . $ref;
         }
 
         $process = new Process($command, $projectPath, $this->buildProcessEnv());
@@ -3446,9 +3444,38 @@ class InstallCommand extends Command
             throw new \RuntimeException('Failed to install project preset.' . ($output !== '' ? ' ' . $output : ''));
         }
 
+        $this->runProjectPresetMigrations($projectPath, $artisan);
+
         $this->steps['presets']['completed'] = true;
         $this->tui->setQuestTrack($this->steps);
         $this->tui->addLog('Project preset installed successfully.', 'success');
+    }
+
+    protected function runProjectPresetMigrations(string $projectPath, string $artisan): void
+    {
+        $this->tui->addLog('Running project preset migrations...');
+
+        $process = new Process([
+            PHP_BINARY ?: 'php',
+            $artisan,
+            'migrate',
+            '--force',
+        ], $projectPath, $this->buildProcessEnv());
+        $process->setTimeout(120);
+        $process->run(function ($type, $buffer) {
+            foreach (preg_split('/\\R/', $buffer) ?: [] as $line) {
+                $line = trim($line);
+                if ($line === '') {
+                    continue;
+                }
+                $this->tui->addLog($line, $type === Process::ERR ? 'warning' : 'info');
+            }
+        });
+
+        if (!$process->isSuccessful()) {
+            $output = trim($process->getOutput() . "\n" . $process->getErrorOutput());
+            throw new \RuntimeException('Project preset migrations failed.' . ($output !== '' ? ' ' . $output : ''));
+        }
     }
 
     protected function shouldSkipProjectPreset(?string $preset): bool
@@ -3480,6 +3507,46 @@ class InstallCommand extends Command
         }
 
         return 'https://github.com/evolution-cms-presets/' . $preset . '.git';
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    protected function resolveProjectPresetSpec(string $preset): array
+    {
+        [$source, $ref] = $this->splitProjectPresetSpec($preset);
+
+        return [$this->resolveProjectPresetSource($source), $ref];
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    protected function splitProjectPresetSpec(string $preset): array
+    {
+        $preset = trim($preset);
+        if ($preset === '' || is_dir($preset)) {
+            return [$preset, ''];
+        }
+
+        foreach (['#', '@'] as $separator) {
+            $pos = strrpos($preset, $separator);
+            if ($pos === false || $pos === 0 || $pos === strlen($preset) - 1) {
+                continue;
+            }
+
+            if ($separator === '@' && str_starts_with($preset, 'git@') && strpos($preset, '@') === $pos) {
+                continue;
+            }
+
+            $source = substr($preset, 0, $pos);
+            $ref = substr($preset, $pos + 1);
+            if ($source !== '' && $ref !== '') {
+                return [$source, $ref];
+            }
+        }
+
+        return [$preset, ''];
     }
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -62,6 +62,7 @@ class InstallCommand extends Command
             ->addOption('github-pat', null, InputOption::VALUE_OPTIONAL, 'GitHub PAT token for API requests')
             ->addOption('github_pat', null, InputOption::VALUE_OPTIONAL, 'GitHub PAT token for API requests')
             ->addOption('branch', null, InputOption::VALUE_OPTIONAL, 'Install from specific Git branch (e.g., develop, nightly, main) instead of latest release')
+            ->addOption('preset-ref', null, InputOption::VALUE_OPTIONAL, 'Git branch/tag for the project-layer preset')
             ->addOption('language', null, InputOption::VALUE_OPTIONAL, 'The installation language')
             ->addOption('composer-clear-cache', null, InputOption::VALUE_NONE, 'Clear Composer cache before install')
             ->addOption('composer-update', null, InputOption::VALUE_NONE, 'Use composer update instead of install during setup')
@@ -123,7 +124,7 @@ class InstallCommand extends Command
         $this->installEvolutionCMS($name, $options);
 
         // Step 5: Install presets
-        $this->installPreset($input->getOption('preset'));
+        $this->installPreset($input->getOption('preset'), $input->getOption('preset-ref'), $name, $options);
 
         // Step 6: Install dependencies
         $this->installDependencies($name, $options);
@@ -3361,14 +3362,124 @@ class InstallCommand extends Command
     /**
      * Install preset.
      */
-    protected function installPreset(?string $preset): void
+    protected function installPreset(?string $preset, ?string $presetRef, string $name, array $options): void
     {
-        $this->steps['presets']['completed'] = true;
-        $this->tui->setQuestTrack($this->steps);
-
-        if ($preset === null) {
+        if ($this->shouldSkipProjectPreset($preset)) {
+            $this->steps['presets']['completed'] = true;
+            $this->tui->setQuestTrack($this->steps);
             return;
         }
+
+        $isCurrentDir = !empty($options['install_in_current_dir']);
+        $projectPath = $isCurrentDir ? $name : (getcwd() . '/' . $name);
+        $artisan = rtrim($projectPath, '/\\') . '/core/artisan';
+
+        if (!is_file($artisan)) {
+            $this->steps['presets']['completed'] = false;
+            $this->tui->setQuestTrack($this->steps);
+            throw new \RuntimeException("Unable to install preset: core/artisan not found in {$projectPath}.");
+        }
+
+        $source = $this->resolveProjectPresetSource((string) $preset);
+        $this->tui->addLog("Installing project preset: {$source}");
+
+        $command = [
+            PHP_BINARY ?: 'php',
+            $artisan,
+            'preset:install',
+            '--from=' . $source,
+            '--force',
+        ];
+
+        $presetRef = trim((string) $presetRef);
+        if ($presetRef !== '') {
+            $command[] = '--ref=' . $presetRef;
+        }
+
+        $process = new Process($command, $projectPath, $this->buildProcessEnv());
+        $timeout = $this->composerTimeoutSeconds();
+        $idleTimeout = $this->composerIdleTimeoutSeconds();
+        if ($timeout > 0) {
+            $process->setTimeout($timeout);
+        }
+        if ($idleTimeout !== null) {
+            $process->setIdleTimeout($idleTimeout);
+        }
+
+        $buffers = [
+            Process::OUT => '',
+            Process::ERR => '',
+        ];
+
+        try {
+            $process->run(function ($type, $buffer) use (&$buffers) {
+                $buffers[$type] .= $buffer;
+
+                while (($pos = strpos($buffers[$type], "\n")) !== false) {
+                    $line = rtrim(substr($buffers[$type], 0, $pos), "\r");
+                    $buffers[$type] = substr($buffers[$type], $pos + 1);
+
+                    if ($line === '') {
+                        continue;
+                    }
+
+                    $this->tui->addLog($line, $type === Process::ERR ? 'warning' : 'info');
+                }
+            });
+        } catch (\Symfony\Component\Process\Exception\ProcessTimedOutException $e) {
+            $this->steps['presets']['completed'] = false;
+            $this->tui->setQuestTrack($this->steps);
+            throw new \RuntimeException('Preset install timed out: ' . $e->getMessage());
+        }
+
+        foreach ($buffers as $type => $buffer) {
+            $line = trim($buffer);
+            if ($line !== '') {
+                $this->tui->addLog($line, $type === Process::ERR ? 'warning' : 'info');
+            }
+        }
+
+        if (!$process->isSuccessful()) {
+            $this->steps['presets']['completed'] = false;
+            $this->tui->setQuestTrack($this->steps);
+            $output = trim($process->getOutput() . "\n" . $process->getErrorOutput());
+            throw new \RuntimeException('Failed to install project preset.' . ($output !== '' ? ' ' . $output : ''));
+        }
+
+        $this->steps['presets']['completed'] = true;
+        $this->tui->setQuestTrack($this->steps);
+        $this->tui->addLog('Project preset installed successfully.', 'success');
+    }
+
+    protected function shouldSkipProjectPreset(?string $preset): bool
+    {
+        $preset = strtolower(trim((string) $preset));
+
+        return $preset === '' || in_array($preset, ['evolution', 'none', 'false', '0'], true);
+    }
+
+    protected function resolveProjectPresetSource(string $preset): string
+    {
+        $preset = trim($preset);
+
+        if ($preset === '') {
+            return $preset;
+        }
+
+        if (is_dir($preset)) {
+            return realpath($preset) ?: $preset;
+        }
+
+        if (preg_match('~^(?:https?://|ssh://|git@|file://)~i', $preset) === 1) {
+            return $preset;
+        }
+
+        if (str_contains($preset, '/')) {
+            $repo = trim($preset, '/');
+            return 'https://github.com/' . $repo . (str_ends_with($repo, '.git') ? '' : '.git');
+        }
+
+        return 'https://github.com/evolution-cms-presets/' . $preset . '.git';
     }
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -35,7 +35,7 @@ class InstallCommand extends Command
         'install' => ['label' => 'Step 4: Install Evolution CMS', 'completed' => false],
         'presets' => ['label' => 'Step 5: Install presets', 'completed' => false],
         'finalize' => ['label' => 'Step 6: Finalize installation', 'completed' => false],
-        'extras' => ['label' => 'Step 7: Install Extras (optional)', 'completed' => false],
+        'extras' => ['label' => 'Step 7: Install Extras', 'completed' => false],
     ];
 
     /**

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -232,6 +232,21 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->assertFalse($cmd->shouldSkipProjectPresetPublic('evolution-cms-presets/default'));
     }
 
+    public function testProjectPresetInstallCommandKeepsLocalPresetSource(): void
+    {
+        $cmd = $this->makeCommand();
+        $presetPath = $this->makeTempProjectDir();
+
+        $local = $cmd->buildProjectPresetInstallCommandPublic('/tmp/core/artisan', $presetPath);
+        $this->assertContains('--keep', $local);
+
+        $remote = $cmd->buildProjectPresetInstallCommandPublic('/tmp/core/artisan', 'https://github.com/evolution-cms-presets/default.git', 'dev');
+        $this->assertNotContains('--keep', $remote);
+        $this->assertContains('--ref=dev', $remote);
+
+        $this->removeTempDir($presetPath);
+    }
+
     private function makeTempProjectDir(): string
     {
         $base = rtrim(sys_get_temp_dir(), '/\\');
@@ -302,5 +317,10 @@ final class TestableInstallCommand extends InstallCommand
     public function resolveProjectPresetSpecPublic(string $preset): array
     {
         return $this->resolveProjectPresetSpec($preset);
+    }
+
+    public function buildProjectPresetInstallCommandPublic(string $artisan, string $source, string $ref = ''): array
+    {
+        return $this->buildProjectPresetInstallCommand($artisan, $source, $ref);
     }
 }

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -202,6 +202,18 @@ final class InstallCommandAdminDirectoryTest extends TestCase
             'https://github.com/evolution-cms-presets/default.git',
             $cmd->resolveProjectPresetSourcePublic('https://github.com/evolution-cms-presets/default.git')
         );
+        $this->assertSame(
+            ['https://github.com/evolution-cms-presets/default.git', 'dev'],
+            $cmd->resolveProjectPresetSpecPublic('default@dev')
+        );
+        $this->assertSame(
+            ['https://github.com/evolution-cms-presets/default.git', 'dev'],
+            $cmd->resolveProjectPresetSpecPublic('evolution-cms-presets/default@dev')
+        );
+        $this->assertSame(
+            ['https://github.com/evolution-cms-presets/default.git', 'dev'],
+            $cmd->resolveProjectPresetSpecPublic('https://github.com/evolution-cms-presets/default.git#dev')
+        );
 
         $projectPath = $this->makeTempProjectDir();
         $this->assertSame(realpath($projectPath), $cmd->resolveProjectPresetSourcePublic($projectPath));
@@ -285,5 +297,10 @@ final class TestableInstallCommand extends InstallCommand
     public function shouldSkipProjectPresetPublic(?string $preset): bool
     {
         return $this->shouldSkipProjectPreset($preset);
+    }
+
+    public function resolveProjectPresetSpecPublic(string $preset): array
+    {
+        return $this->resolveProjectPresetSpec($preset);
     }
 }

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -186,6 +186,40 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->removeTempDir($projectPath);
     }
 
+    public function testResolveProjectPresetSourceSupportsNamesReposUrlsAndLocalPaths(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $this->assertSame(
+            'https://github.com/evolution-cms-presets/default.git',
+            $cmd->resolveProjectPresetSourcePublic('default')
+        );
+        $this->assertSame(
+            'https://github.com/evolution-cms-presets/default.git',
+            $cmd->resolveProjectPresetSourcePublic('evolution-cms-presets/default')
+        );
+        $this->assertSame(
+            'https://github.com/evolution-cms-presets/default.git',
+            $cmd->resolveProjectPresetSourcePublic('https://github.com/evolution-cms-presets/default.git')
+        );
+
+        $projectPath = $this->makeTempProjectDir();
+        $this->assertSame(realpath($projectPath), $cmd->resolveProjectPresetSourcePublic($projectPath));
+        $this->removeTempDir($projectPath);
+    }
+
+    public function testShouldSkipProjectPresetKeepsEvolutionAsCoreOnlyInstall(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $this->assertTrue($cmd->shouldSkipProjectPresetPublic(null));
+        $this->assertTrue($cmd->shouldSkipProjectPresetPublic(''));
+        $this->assertTrue($cmd->shouldSkipProjectPresetPublic('evolution'));
+        $this->assertTrue($cmd->shouldSkipProjectPresetPublic('none'));
+        $this->assertFalse($cmd->shouldSkipProjectPresetPublic('default'));
+        $this->assertFalse($cmd->shouldSkipProjectPresetPublic('evolution-cms-presets/default'));
+    }
+
     private function makeTempProjectDir(): string
     {
         $base = rtrim(sys_get_temp_dir(), '/\\');
@@ -241,5 +275,15 @@ final class TestableInstallCommand extends InstallCommand
     public function finalizeInstallationPublic(string $projectPath, array $options): void
     {
         $this->finalizeInstallation($projectPath, $options);
+    }
+
+    public function resolveProjectPresetSourcePublic(string $preset): string
+    {
+        return $this->resolveProjectPresetSource($preset);
+    }
+
+    public function shouldSkipProjectPresetPublic(?string $preset): bool
+    {
+        return $this->shouldSkipProjectPreset($preset);
     }
 }


### PR DESCRIPTION
## Summary
- add project preset support to the Go installer and pass selected preset specs to the PHP install command
- show installer version in the TUI header alongside the Evolution target version
- add a dedicated `Choose project preset` quest step so the active menu matches the current action
- default preset picker to `No project preset`, then custom source, then public `evolution-cms-presets` entries
- remove the separate Extras yes/no prompt and open the Extras selection screen directly with default selections ready for Enter
- make Extras selection friendlier with search, hidden Legacy Store toggle, selected count in the install action, and duplicate package cleanup such as TinyMCE4
- support Legacy Store package IDs in `--extras` for CLI mode and document the syntax
- keep managed Extras Composer constraints floating (`*`) by default and preserve local/custom preset sources
- update README examples without machine-specific paths

## Validation
- `go test ./...`
- `php -l src/Commands/InstallCommand.php`
- `composer test`
- `git diff --check`