### PR TITLE
fix(extras): [FIX] normalize bootstrap paths on Windows

### DIFF
--- a/internal/engine/install/extras_helper.php
+++ b/internal/engine/install/extras_helper.php
@@ -29,14 +29,21 @@ function helper_read_json(string $path): array
     return $data;
 }
 
+function helper_evo_path(string $path): string
+{
+    return rtrim(str_replace('\\', '/', $path), '/') . '/';
+}
+
 function helper_bootstrap(string $projectPath): void
 {
+    $basePath = helper_evo_path($projectPath);
+
     defined('EVO_API_MODE') || define('EVO_API_MODE', true);
     defined('IN_INSTALL_MODE') || define('IN_INSTALL_MODE', true);
     defined('IN_MANAGER_MODE') || define('IN_MANAGER_MODE', false);
     defined('EVO_CLI') || define('EVO_CLI', true);
-    defined('EVO_BASE_PATH') || define('EVO_BASE_PATH', rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
-    defined('EVO_CORE_PATH') || define('EVO_CORE_PATH', EVO_BASE_PATH . 'core' . DIRECTORY_SEPARATOR);
+    defined('EVO_BASE_PATH') || define('EVO_BASE_PATH', $basePath);
+    defined('EVO_CORE_PATH') || define('EVO_CORE_PATH', $basePath . 'core/');
     defined('EVO_BASE_URL') || define('EVO_BASE_URL', '/');
     defined('EVO_SITE_URL') || define('EVO_SITE_URL', '/');
 
@@ -897,7 +904,7 @@ if ($projectPath === '' || $mode === '' || $payloadPath === '') {
     helper_fail('Usage: php extras_helper.php <project-path> <mode> <payload.json>');
 }
 
-$projectPath = rtrim((string) realpath($projectPath), DIRECTORY_SEPARATOR);
+$projectPath = rtrim((string) realpath($projectPath), '/\\');
 if ($projectPath === '') {
     helper_fail('Project path is invalid.');
 }

--- a/internal/engine/install/extras_test.go
+++ b/internal/engine/install/extras_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/evolution-cms/installer/internal/domain"
@@ -472,6 +473,23 @@ func TestDedupeExtrasPackagesPrefersManagedOverLegacyDuplicate(t *testing.T) {
 	}
 	if !foundTiny {
 		t.Fatalf("expected TinyMCE4 in deduped packages: %#v", pkgs)
+	}
+}
+
+func TestExtrasHelperUsesCoreCompatiblePathSeparators(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(extrasHelperPHP, "function helper_evo_path(string $path): string") {
+		t.Fatalf("expected extras helper to define EVO path normalization")
+	}
+	if !strings.Contains(extrasHelperPHP, "define('EVO_BASE_PATH', $basePath)") {
+		t.Fatalf("expected EVO_BASE_PATH to use normalized forward-slash path")
+	}
+	if !strings.Contains(extrasHelperPHP, "define('EVO_CORE_PATH', $basePath . 'core/')") {
+		t.Fatalf("expected EVO_CORE_PATH to use normalized forward-slash path")
+	}
+	if strings.Contains(extrasHelperPHP, "define('EVO_BASE_PATH', rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)") {
+		t.Fatalf("EVO_BASE_PATH must not use DIRECTORY_SEPARATOR because define.inc.php requires trailing slash")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #46.
- Normalizes `EVO_BASE_PATH` and `EVO_CORE_PATH` in the bundled extras helper to forward-slash paths before bootstrapping Evolution CMS.
- Keeps native filesystem paths for `chdir()` and file operations, but gives the core constants the path format expected by `core/includes/define.inc.php`.
- Adds a regression test so the helper does not go back to `DIRECTORY_SEPARATOR` for EVO path constants.

## Why
On Windows, `DIRECTORY_SEPARATOR` makes `EVO_BASE_PATH` end with `\`. Evolution CMS core validates `EVO_BASE_PATH` with a trailing `/`, so the temporary extras helper can fail during the final bundled extras stage even after migrations succeed. This matches the reported `define.inc.php` failure and is independent of the selected database driver.

## Validation
- `php -l internal/engine/install/extras_helper.php`
- `go test ./internal/engine/install`
- `go test ./...`
- `vendor-php/bin/phpunit --filter InstallCommandAdminDirectoryTest`
- `git diff --check`