### PR TITLE
Fix htaccess rewrites for custom admin directory

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3800,6 +3800,7 @@ class InstallCommand extends Command
                 $this->tui->addLog('Failed to rename ht.access to .htaccess.', 'warning');
             }
         }
+        $this->updateRootHtaccessForAdminDirectory($projectPath, $options);
 
         // Clean up seeders directory (remove files inside, keep directory)
         $seedersDir = $projectPath . '/core/database/seeders';
@@ -3943,10 +3944,60 @@ class InstallCommand extends Command
 
         if (@rename($source, $target)) {
             $this->tui?->addLog("Renamed manager directory to {$adminDir}.");
+            $this->updateManagerHtaccessForAdminDirectory($target, $adminDir);
             return;
         }
 
         $this->tui?->addLog("Failed to rename manager directory to {$adminDir}.", 'warning');
+    }
+
+    protected function updateManagerHtaccessForAdminDirectory(string $managerPath, string $adminDir): void
+    {
+        $htaccess = rtrim($managerPath, '/\\') . DIRECTORY_SEPARATOR . '.htaccess';
+        if (!is_file($htaccess) || !is_readable($htaccess) || !is_writable($htaccess)) {
+            return;
+        }
+
+        $contents = (string) file_get_contents($htaccess);
+        $updated = str_replace('RewriteBase /manager/', 'RewriteBase /' . $adminDir . '/', $contents);
+
+        if ($updated !== $contents && @file_put_contents($htaccess, $updated) !== false) {
+            $this->tui?->addLog("Updated admin .htaccess RewriteBase for {$adminDir}.");
+        }
+    }
+
+    protected function updateRootHtaccessForAdminDirectory(string $projectPath, array $options): void
+    {
+        $adminDir = $this->sanitizeAdminDirectory($options['admin']['directory'] ?? null);
+        if ($adminDir === 'manager') {
+            return;
+        }
+
+        $htaccess = rtrim($projectPath, '/\\') . DIRECTORY_SEPARATOR . '.htaccess';
+        if (!is_file($htaccess) || !is_readable($htaccess) || !is_writable($htaccess)) {
+            return;
+        }
+
+        $contents = (string) file_get_contents($htaccess);
+        $updated = preg_replace_callback(
+            '/RewriteRule\s+\^\(([^)]*)\)\/\.\*\$\s+-\s+\[L\]/',
+            static function (array $matches) use ($adminDir): string {
+                $directories = explode('|', $matches[1]);
+                $directories = array_map(
+                    static fn (string $directory): string => $directory === 'manager' ? $adminDir : $directory,
+                    $directories
+                );
+                $directories = array_values(array_unique($directories));
+
+                return 'RewriteRule ^(' . implode('|', $directories) . ')/.*$ - [L]';
+            },
+            $contents,
+            1
+        );
+
+        if (is_string($updated) && $updated !== $contents && @file_put_contents($htaccess, $updated) !== false) {
+            $this->tui?->addLog("Updated root .htaccess rewrite exclusions for {$adminDir}.");
+        }
     }
 
     /**

--- a/tests/Unit/InstallCommandAdminDirectoryTest.php
+++ b/tests/Unit/InstallCommandAdminDirectoryTest.php
@@ -186,6 +186,27 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->removeTempDir($projectPath);
     }
 
+    public function testApplyManagerDirectoryUpdatesManagerHtaccessRewriteBase(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $projectPath = $this->makeTempProjectDir();
+        @mkdir($projectPath . '/manager', 0755, true);
+        file_put_contents($projectPath . '/manager/.htaccess', "RewriteEngine On\nRewriteBase /manager/\n");
+
+        $cmd->applyManagerDirectoryPublic($projectPath, [
+            'admin' => [
+                'directory' => 'admin',
+            ],
+        ]);
+
+        $this->assertFileExists($projectPath . '/admin/.htaccess');
+        $this->assertStringContainsString('RewriteBase /admin/', (string) file_get_contents($projectPath . '/admin/.htaccess'));
+        $this->assertStringNotContainsString('RewriteBase /manager/', (string) file_get_contents($projectPath . '/admin/.htaccess'));
+
+        $this->removeTempDir($projectPath);
+    }
+
     public function testResolveProjectPresetSourceSupportsNamesReposUrlsAndLocalPaths(): void
     {
         $cmd = $this->makeCommand();
@@ -245,6 +266,29 @@ final class InstallCommandAdminDirectoryTest extends TestCase
         $this->assertContains('--ref=dev', $remote);
 
         $this->removeTempDir($presetPath);
+    }
+
+    public function testRootHtaccessUsesSelectedAdminDirectory(): void
+    {
+        $cmd = $this->makeCommand();
+
+        $projectPath = $this->makeTempProjectDir();
+        file_put_contents(
+            $projectPath . '/.htaccess',
+            "RewriteEngine On\nRewriteRule ^(manager|assets|js|css|images|img)/.*$ - [L]\n"
+        );
+
+        $cmd->updateRootHtaccessForAdminDirectoryPublic($projectPath, [
+            'admin' => [
+                'directory' => 'admin',
+            ],
+        ]);
+
+        $htaccess = (string) file_get_contents($projectPath . '/.htaccess');
+        $this->assertStringContainsString('RewriteRule ^(admin|assets|js|css|images|img)/.*$ - [L]', $htaccess);
+        $this->assertStringNotContainsString('^(manager|assets', $htaccess);
+
+        $this->removeTempDir($projectPath);
     }
 
     private function makeTempProjectDir(): string
@@ -322,5 +366,10 @@ final class TestableInstallCommand extends InstallCommand
     public function buildProjectPresetInstallCommandPublic(string $artisan, string $source, string $ref = ''): array
     {
         return $this->buildProjectPresetInstallCommand($artisan, $source, $ref);
+    }
+
+    public function updateRootHtaccessForAdminDirectoryPublic(string $projectPath, array $options): void
+    {
+        $this->updateRootHtaccessForAdminDirectory($projectPath, $options);
     }
 }


### PR DESCRIPTION
## Summary
- Replace the default manager rewrite exclusion in the generated root .htaccess with the sanitized admin directory selected during install.
- Update the renamed manager directory .htaccess from RewriteBase /manager/ to the selected admin directory.
- Add unit coverage for both root and manager .htaccess updates.

## Why
When Evolution CMS is installed with a custom manager directory, the installer renames manager and writes MGR_DIR, but the generated .htaccess files can still contain the default manager path. As a result, manager package endpoints such as /custom-admin/evo-ui?... may be rewritten by frontend friendly URL rules or use the wrong RewriteBase.

This PR keeps the installer generic: it does not hardcode any project-specific manager directory name. It replaces manager with the actual directory chosen by the user during installation.

## Changed files
- src/Commands/InstallCommand.php — added post-install .htaccess normalization for the selected admin directory.
- 	ests/Unit/InstallCommandAdminDirectoryTest.php — added regression tests for manager .htaccess RewriteBase and root .htaccess rewrite exclusions.

## Checks
- php8.4 -l src/Commands/InstallCommand.php
- php8.4 -l tests/Unit/InstallCommandAdminDirectoryTest.php
- git diff --check

## Not run
- PHPUnit target test: local endor-php/bin/phpunit is absent in this checkout, and dependencies were not installed to avoid unrelated workspace noise.